### PR TITLE
Introduce extension points for builders and loggers.

### DIFF
--- a/ReportGenerator.Reporting/Properties/AssemblyInfo.cs
+++ b/ReportGenerator.Reporting/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.4.3.0")]
-[assembly: AssemblyFileVersion("2.4.3.0")]
+[assembly: AssemblyVersion("2.4.4.0")]
+[assembly: AssemblyFileVersion("2.4.4.0")]
 
 [assembly: CLSCompliant(true)]

--- a/ReportGenerator/Generator.cs
+++ b/ReportGenerator/Generator.cs
@@ -1,0 +1,73 @@
+﻿using Palmmedia.ReportGenerator.Logging;
+using Palmmedia.ReportGenerator.Parser;
+using Palmmedia.ReportGenerator.Properties;
+using Palmmedia.ReportGenerator.Reporting;
+using System;
+
+namespace Palmmedia.ReportGenerator
+{
+    /// <summary>
+    /// The report generator implementation.
+    /// </summary>
+    public class Generator : IReportGenerator
+    {
+        /// <summary>
+        /// The Logger.
+        /// </summary>
+        private static readonly ILogger Logger = LoggerFactory.GetLogger(typeof(Program));
+        
+        /// <summary>
+        /// Executes the report generation.
+        /// </summary>
+        /// <param name="configuration">The configuration.</param>
+        /// <returns><c>true</c> if report was generated successfully; otherwise <c>false</c>.</returns>
+        public bool GenerateReport(ReportConfiguration configuration)
+        {
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            // set it before validate
+            LoggerFactory.VerbosityLevel = configuration.VerbosityLevel;
+            if (!configuration.Validate())
+            {
+                return false;
+            }
+
+            var stopWatch = new System.Diagnostics.Stopwatch();
+            stopWatch.Start();
+            DateTime executionTime = DateTime.Now;
+
+            var parser = ParserFactory.CreateParser(configuration.ReportFiles, configuration.SourceDirectories);
+
+            if (configuration.HistoryDirectory != null)
+            {
+                new Reporting.HistoryParser(
+                    parser.Assemblies,
+                    configuration.HistoryDirectory)
+                        .ApplyHistoricCoverage();
+            }
+
+            new Reporting.ReportGenerator(
+                parser,
+                new DefaultFilter(configuration.AssemblyFilters),
+                new DefaultFilter(configuration.ClassFilters),
+                configuration.ReportBuilderFactory.GetReportBuilders(configuration.TargetDirectory, configuration.ReportTypes))
+                    .CreateReport(configuration.HistoryDirectory != null, executionTime);
+
+            if (configuration.HistoryDirectory != null)
+            {
+                new Reporting.HistoryReportGenerator(
+                    parser,
+                    configuration.HistoryDirectory)
+                        .CreateReport(executionTime);
+            }
+
+            stopWatch.Stop();
+            Logger.InfoFormat(Resources.ReportGenerationTook, stopWatch.ElapsedMilliseconds / 1000d);
+
+            return true;
+        }
+    }
+}

--- a/ReportGenerator/IReportGenerator.cs
+++ b/ReportGenerator/IReportGenerator.cs
@@ -1,0 +1,15 @@
+﻿namespace Palmmedia.ReportGenerator
+{
+    /// <summary>
+    /// Provides report generation capabilities.
+    /// </summary>
+    public interface IReportGenerator
+    {
+        /// <summary>
+        /// Generates a report using given configuration.
+        /// </summary>
+        /// <param name="reportConfiguration">The report configuration.</param>
+        /// <returns>True if the report generation succeeded, otherwise false.</returns>
+        bool GenerateReport(ReportConfiguration reportConfiguration);
+    }
+}

--- a/ReportGenerator/Logging/ConsoleLogger.cs
+++ b/ReportGenerator/Logging/ConsoleLogger.cs
@@ -10,7 +10,7 @@ namespace Palmmedia.ReportGenerator.Logging
         /// <summary>
         /// Gets or sets the verbosity level.
         /// </summary>
-        public VerbosityLevel VerbosityLevel { private get; set; }
+        public VerbosityLevel VerbosityLevel { get; set; }
 
         /// <summary>
         /// Log a message at DEBUG level.

--- a/ReportGenerator/Logging/ConsoleLoggerFactory.cs
+++ b/ReportGenerator/Logging/ConsoleLoggerFactory.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Palmmedia.ReportGenerator.Logging
+{
+    /// <summary>
+    /// A logger factory creating console loggers.
+    /// </summary>
+    internal class ConsoleLoggerFactory : ILoggerFactory
+    {
+        /// <summary>
+        /// The cached logger.
+        /// </summary>
+        private static readonly ILogger Logger = new ConsoleLogger();
+
+        /// <summary>
+        /// Gets or sets the verbosity of console loggers.
+        /// </summary>
+        public VerbosityLevel VerbosityLevel
+        {
+            get
+            {
+                return Logger.VerbosityLevel;
+            }
+            set
+            {
+                Logger.VerbosityLevel = value;
+            }
+        }
+
+        /// <summary>
+        /// Initializes the logger for the given type.
+        /// </summary>
+        /// <param name="type">The type of the class that uses the logger.</param>
+        /// <returns>The logger.</returns>
+        public ILogger GetLogger(Type type) => Logger;
+    }
+}

--- a/ReportGenerator/Logging/ILogger.cs
+++ b/ReportGenerator/Logging/ILogger.cs
@@ -3,12 +3,12 @@
     /// <summary>
     /// Interface for loggers.
     /// </summary>
-    internal interface ILogger
+    public interface ILogger
     {
         /// <summary>
-        /// Sets the verbosity level.
+        /// Gets or sets the verbosity level.
         /// </summary>
-        VerbosityLevel VerbosityLevel { set; }
+        VerbosityLevel VerbosityLevel { get; set; }
 
         /// <summary>
         /// Log a message at DEBUG level.

--- a/ReportGenerator/Logging/ILoggerFactory.cs
+++ b/ReportGenerator/Logging/ILoggerFactory.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Palmmedia.ReportGenerator.Logging
+{
+    /// <summary>
+    /// Provides <see cref="ILogger"/> objects creation capabilities.
+    /// </summary>
+    public interface ILoggerFactory
+    {
+        /// <summary>
+        /// Gets or sets the verbosity of <see cref="ILogger"/> objects.
+        /// </summary>
+        VerbosityLevel VerbosityLevel { get; set; }
+
+        /// <summary>
+        /// Initializes the logger for the given type.
+        /// </summary>
+        /// <param name="type">The type of the class that uses the logger.</param>
+        /// <returns>The logger.</returns>
+        ILogger GetLogger(Type type);
+    }
+}

--- a/ReportGenerator/Logging/LoggerFactory.cs
+++ b/ReportGenerator/Logging/LoggerFactory.cs
@@ -5,29 +5,54 @@ namespace Palmmedia.ReportGenerator.Logging
     /// <summary>
     /// Factory for loggers.
     /// </summary>
-    internal class LoggerFactory
+    public class LoggerFactory
     {
         /// <summary>
-        /// The cached logger.
+        /// Inner factory synchronization object.
         /// </summary>
-        private static readonly ILogger Logger = new ConsoleLogger();
+        private static readonly object innerFactorySync = new object();
 
         /// <summary>
-        /// Sets the verbosity level.
+        /// Inner factory.
+        /// </summary>
+        private static volatile ILoggerFactory innerFactory = new ConsoleLoggerFactory();
+        
+        /// <summary>
+        /// Set the verbosity level of loggers.
         /// </summary>
         public static VerbosityLevel VerbosityLevel
         {
             set
             {
-                Logger.VerbosityLevel = value;
+                innerFactory.VerbosityLevel = value;
             }
         }
 
         /// <summary>
         /// Initializes the logger for the given type.
         /// </summary>
-        /// <param name="tpye">The type of the class that uses the logger.</param>
+        /// <param name="type">The type of the class that uses the logger.</param>
         /// <returns>The logger.</returns>
-        public static ILogger GetLogger(Type tpye) => Logger;
+        public static ILogger GetLogger(Type type)
+        {
+            return innerFactory.GetLogger(type);
+        }
+
+        /// <summary>
+        /// Configures the inner logger factory.
+        /// </summary>
+        /// <param name="factory">The inner logger factory.</param>
+        public static void Configure(ILoggerFactory factory)
+        {
+            if (factory == null)
+            {
+                throw new ArgumentNullException(nameof(factory));
+            }
+
+            lock (innerFactorySync)
+            {
+                innerFactory = factory;
+            }
+        }
     }
 }

--- a/ReportGenerator/Logging/VerbosityLevel.cs
+++ b/ReportGenerator/Logging/VerbosityLevel.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Enumeration for the logging verbosity.
     /// </summary>
-    internal enum VerbosityLevel
+    public enum VerbosityLevel
     {
         /// <summary>
         /// All messages are logged.

--- a/ReportGenerator/MSBuild/ReportGenerator.cs
+++ b/ReportGenerator/MSBuild/ReportGenerator.cs
@@ -113,7 +113,8 @@ namespace Palmmedia.ReportGenerator.MSBuild
                 this.ClassFilters == null ? Enumerable.Empty<string>() : this.ClassFilters.Select(r => r.ItemSpec),
                 this.VerbosityLevel);
 
-            return Program.Execute(configuration);
+            var generator = new Generator();
+            return generator.GenerateReport(configuration);
         }
     }
 }

--- a/ReportGenerator/Program.cs
+++ b/ReportGenerator/Program.cs
@@ -1,9 +1,6 @@
-﻿using System;
+﻿using Palmmedia.ReportGenerator.Reporting;
+using System;
 using System.Linq;
-using Palmmedia.ReportGenerator.Logging;
-using Palmmedia.ReportGenerator.Parser;
-using Palmmedia.ReportGenerator.Properties;
-using Palmmedia.ReportGenerator.Reporting;
 
 namespace Palmmedia.ReportGenerator
 {
@@ -13,65 +10,6 @@ namespace Palmmedia.ReportGenerator
     internal class Program
     {
         /// <summary>
-        /// The Logger.
-        /// </summary>
-        private static readonly ILogger Logger = LoggerFactory.GetLogger(typeof(Program));
-
-        /// <summary>
-        /// Executes the report generation.
-        /// </summary>
-        /// <param name="configuration">The configuration.</param>
-        /// <returns><c>true</c> if report was generated successfully; otherwise <c>false</c>.</returns>
-        internal static bool Execute(ReportConfiguration configuration)
-        {
-            if (configuration == null)
-            {
-                throw new ArgumentNullException(nameof(configuration));
-            }
-
-            if (!configuration.Validate())
-            {
-                return false;
-            }
-
-            LoggerFactory.VerbosityLevel = configuration.VerbosityLevel;
-
-            var stopWatch = new System.Diagnostics.Stopwatch();
-            stopWatch.Start();
-            DateTime executionTime = DateTime.Now;
-
-            var parser = ParserFactory.CreateParser(configuration.ReportFiles, configuration.SourceDirectories);
-
-            if (configuration.HistoryDirectory != null)
-            {
-                new Reporting.HistoryParser(
-                    parser.Assemblies,
-                    configuration.HistoryDirectory)
-                        .ApplyHistoricCoverage();
-            }
-
-            new Reporting.ReportGenerator(
-                parser,
-                new DefaultFilter(configuration.AssemblyFilters),
-                new DefaultFilter(configuration.ClassFilters),
-                configuration.ReportBuilderFactory.GetReportBuilders(configuration.TargetDirectory, configuration.ReportTypes))
-                    .CreateReport(configuration.HistoryDirectory != null, executionTime);
-
-            if (configuration.HistoryDirectory != null)
-            {
-                new Reporting.HistoryReportGenerator(
-                    parser,
-                    configuration.HistoryDirectory)
-                        .CreateReport(executionTime);
-            }
-
-            stopWatch.Stop();
-            Logger.InfoFormat(Resources.ReportGenerationTook, stopWatch.ElapsedMilliseconds / 1000d);
-
-            return true;
-        }
-
-        /// <summary>
         /// The main method.
         /// </summary>
         /// <param name="args">The command line arguments.</param>
@@ -79,7 +17,6 @@ namespace Palmmedia.ReportGenerator
         internal static int Main(string[] args)
         {
             var reportConfigurationBuilder = new ReportConfigurationBuilder(new MefReportBuilderFactory());
-
             if (args.Length < 2)
             {
                 reportConfigurationBuilder.ShowHelp();
@@ -89,8 +26,8 @@ namespace Palmmedia.ReportGenerator
             args = args.Select(a => a.EndsWith("\"", StringComparison.OrdinalIgnoreCase) ? a.TrimEnd('\"') + "\\" : a).ToArray();
 
             ReportConfiguration configuration = reportConfigurationBuilder.Create(args);
-
-            return Execute(configuration) ? 0 : 1;
+            var generator = new Generator();
+            return generator.GenerateReport(configuration) ? 0 : 1;
         }
     }
 }

--- a/ReportGenerator/Properties/AssemblyInfo.cs
+++ b/ReportGenerator/Properties/AssemblyInfo.cs
@@ -33,8 +33,8 @@ using System.Runtime.InteropServices;
 // Sie können alle Werte angeben oder die standardmäßigen Build- und Revisionsnummern 
 // übernehmen, indem Sie "*" eingeben:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.4.3.0")]
-[assembly: AssemblyFileVersion("2.4.3.0")]
+[assembly: AssemblyVersion("2.4.4.0")]
+[assembly: AssemblyFileVersion("2.4.4.0")]
 [assembly: NeutralResourcesLanguageAttribute("en-US")]
 
 [assembly: CLSCompliant(true)]

--- a/ReportGenerator/ReportConfiguration.cs
+++ b/ReportGenerator/ReportConfiguration.cs
@@ -12,7 +12,7 @@ namespace Palmmedia.ReportGenerator
     /// <summary>
     /// Provides all parameters that are required for report generation.
     /// </summary>
-    internal class ReportConfiguration
+    public class ReportConfiguration
     {
         /// <summary>
         /// The Logger.
@@ -46,7 +46,7 @@ namespace Palmmedia.ReportGenerator
         /// <param name="assemblyFilters">The assembly filters.</param>
         /// <param name="classFilters">The class filters.</param>
         /// <param name="verbosityLevel">The verbosity level.</param>
-        internal ReportConfiguration(
+        public ReportConfiguration(
             IReportBuilderFactory reportBuilderFactory,
             IEnumerable<string> reportFilePatterns,
             string targetDirectory,
@@ -61,7 +61,7 @@ namespace Palmmedia.ReportGenerator
             {
                 throw new ArgumentNullException(nameof(reportBuilderFactory));
             }
-
+            
             if (reportFilePatterns == null)
             {
                 throw new ArgumentNullException(nameof(reportFilePatterns));
@@ -93,7 +93,6 @@ namespace Palmmedia.ReportGenerator
             }
 
             this.ReportBuilderFactory = reportBuilderFactory;
-
             foreach (var reportFilePattern in reportFilePatterns)
             {
                 try
@@ -133,47 +132,47 @@ namespace Palmmedia.ReportGenerator
         /// <summary>
         /// Gets the report builder factory.
         /// </summary>
-        internal IReportBuilderFactory ReportBuilderFactory { get; }
+        public IReportBuilderFactory ReportBuilderFactory { get; }
 
         /// <summary>
         /// Gets the report files.
         /// </summary>
-        internal IEnumerable<string> ReportFiles => this.reportFiles;
+        public IEnumerable<string> ReportFiles => this.reportFiles;
 
         /// <summary>
         /// Gets the target directory.
         /// </summary>
-        internal string TargetDirectory { get; }
+        public string TargetDirectory { get; }
 
         /// <summary>
         /// Gets the history directory.
         /// </summary>
-        internal string HistoryDirectory { get; }
+        public string HistoryDirectory { get; }
 
         /// <summary>
         /// Gets the type of the report.
         /// </summary>
-        internal IEnumerable<string> ReportTypes { get; }
+        public IEnumerable<string> ReportTypes { get; }
 
         /// <summary>
         /// Gets the source directories.
         /// </summary>
-        internal IEnumerable<string> SourceDirectories { get; }
+        public IEnumerable<string> SourceDirectories { get; }
 
         /// <summary>
         /// Gets the assembly filters.
         /// </summary>
-        internal IEnumerable<string> AssemblyFilters { get; }
+        public IEnumerable<string> AssemblyFilters { get; }
 
         /// <summary>
         /// Gets the class filters.
         /// </summary>
-        internal IEnumerable<string> ClassFilters { get; }
+        public IEnumerable<string> ClassFilters { get; }
 
         /// <summary>
         /// Gets the verbosity level.
         /// </summary>
-        internal VerbosityLevel VerbosityLevel { get; }
+        public VerbosityLevel VerbosityLevel { get; }
 
         /// <summary>
         /// Validates all parameters.

--- a/ReportGenerator/ReportGenerator.csproj
+++ b/ReportGenerator/ReportGenerator.csproj
@@ -109,8 +109,11 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Common\FileSearch.cs" />
+    <Compile Include="IReportGenerator.cs" />
     <Compile Include="Logging\ConsoleLogger.cs" />
+    <Compile Include="Logging\ConsoleLoggerFactory.cs" />
     <Compile Include="Logging\ILogger.cs" />
+    <Compile Include="Logging\ILoggerFactory.cs" />
     <Compile Include="Logging\LoggerFactory.cs" />
     <Compile Include="Parser\Analysis\Branch.cs" />
     <Compile Include="Parser\Analysis\HistoricCoverage.cs" />
@@ -160,6 +163,7 @@
     <Compile Include="Parser\Analysis\FileAnalysis.cs" />
     <Compile Include="Parser\Analysis\ShortLineAnalysis.cs" />
     <Compile Include="Parser\Analysis\LineVisitStatus.cs" />
+    <Compile Include="Generator.cs" />
     <Compile Include="Reporting\DefaultFilter.cs" />
     <Compile Include="Reporting\FileUnblocker.cs" />
     <Compile Include="Reporting\HistoryParser.cs" />

--- a/ReportGenerator/Reporting/IReportBuilderFactory.cs
+++ b/ReportGenerator/Reporting/IReportBuilderFactory.cs
@@ -5,7 +5,7 @@ namespace Palmmedia.ReportGenerator.Reporting
     /// <summary>
     /// Interface for factories that create instances of <see cref="IReportBuilder"/>.
     /// </summary>
-    internal interface IReportBuilderFactory
+    public interface IReportBuilderFactory
     {
         /// <summary>
         /// Gets the available report types.

--- a/ReportGeneratorTest/Properties/AssemblyInfo.cs
+++ b/ReportGeneratorTest/Properties/AssemblyInfo.cs
@@ -31,6 +31,6 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("2.4.3.0")]
-[assembly: AssemblyFileVersion("2.4.3.0")]
+[assembly: AssemblyVersion("2.4.4.0")]
+[assembly: AssemblyFileVersion("2.4.4.0")]
 [assembly: NeutralResourcesLanguageAttribute("en-US")]


### PR DESCRIPTION
Hi. Could you consider my changes to be merged with the master line.

### Racionale

Recently I tried to use the ReportGenerator as a library for my project. What I wanted to do is to implement a bunch of my own report builders and a custom logging. I was using Autofac, not MEF for the composition.

Unfortunately, it is currently impossible to inject a custom logger factory or a report builder factory other than MEF-based since those interfaces are internal. Additionally, there is no way of executing the generation other than instantiating the ReportGenerator MSBuild task.
These limitations prevented me from extending the tool the way I wanted.

Please check whether my changes align with your design guidelines and would be good for the project as I'd rather not to publish a ReportGenerator2 on nuget.org just because I need it. :)
