### PR TITLE
Add stripped lines on Summary Table to help with readability

### DIFF
--- a/ReportGenerator.Reporting/Rendering/HtmlRenderer.cs
+++ b/ReportGenerator.Reporting/Rendering/HtmlRenderer.cs
@@ -250,7 +250,7 @@ namespace Palmmedia.ReportGenerator.Reporting.Rendering
                 WebUtility.HtmlEncode(ReportResources.ShowCustomizeBoxHelp));
             this.reportTextWriter.WriteLine("</div>");
 
-            this.reportTextWriter.WriteLine("<table data-ng-if=\"!filteringEnabled\" class=\"overview table-fixed\">");
+            this.reportTextWriter.WriteLine("<table data-ng-if=\"!filteringEnabled\" class=\"overview table-fixed stripped\">");
             this.reportTextWriter.WriteLine("<colgroup>");
             this.reportTextWriter.WriteLine("<col />");
             this.reportTextWriter.WriteLine("<col class=\"column90\" />");

--- a/ReportGenerator.Reporting/Rendering/resources/custom.css
+++ b/ReportGenerator.Reporting/Rendering/resources/custom.css
@@ -36,6 +36,7 @@ th { text-align: left; }
 .overview td { border: solid 1px #c1c1c1; border-collapse: collapse; padding: 2px 5px 2px 5px; }
 .coverage { border: solid 1px #c1c1c1; border-collapse: collapse; font-size: 5px; height: 10px; }
 .coverage td { padding: 0; border: none; }
+.stripped tr:nth-child(2n+1) { background-color: #F3F3F3; }
 
 .customizebox { font-size: 0.75em; margin-bottom: 7px; }
 .customizebox div { width: 33.33%; display: inline-block; }


### PR DESCRIPTION
Reading the table as it is today is very hard.

I styled the CSS to show a light-gray color on even lines.

![spotify_2017-09-08_15-26-23](https://user-images.githubusercontent.com/954102/30225841-4e77074c-94aa-11e7-801b-49fb5f2d7145.png)

I also applied this only to the summary table, the other tables are mainly key-value, which didn't make sense.