### PR TITLE
Add MSBuild task definition to the NuGet package

### DIFF
--- a/src/Deployment/nuget/ReportGenerator.nuspec
+++ b/src/Deployment/nuget/ReportGenerator.nuspec
@@ -25,5 +25,6 @@
     <file src="..\..\target\bin\Release\ReportGenerator.Reporting.XML" target="tools" />
     <file src="..\..\target\bin\Release\LICENSE.txt" target="LICENSE.txt" />
     <file src="..\..\target\bin\Release\Readme.txt" target="Readme.txt" />
+    <file src=".\ReportGenerator.props" target="build" />
   </files>
 </package>

--- a/src/Deployment/nuget/ReportGenerator.props
+++ b/src/Deployment/nuget/ReportGenerator.props
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
-  <UsingTask TaskName="ReportGenerator" AssemblyFile="$(MSBuildThisFileDirectory)\..\tools\ReportGenerator.exe" />
+  <PropertyGroup>
+    <ReportGeneratorAssembly>$(MSBuildThisFileDirectory)\..\tools\ReportGenerator.exe</ReportGeneratorAssembly>
+  </PropertyGroup>
+  <UsingTask TaskName="ReportGenerator" AssemblyFile="$(ReportGeneratorAssembly)" />
 </Project>

--- a/src/Deployment/nuget/ReportGenerator.props
+++ b/src/Deployment/nuget/ReportGenerator.props
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <UsingTask TaskName="ReportGenerator" AssemblyFile="$(MSBuildThisFileDirectory)\..\tools\ReportGenerator.exe" />
+</Project>


### PR DESCRIPTION
The PR adds MSBuild task definition to the NuGet package, so it can be used in a project by name w/o locating the assembly (e.g., for a `PackageReference` reference).