### PR TITLE
OpenCover parser ignores classes with only async methods

### DIFF
--- a/src/ReportGenerator.Core/Parser/OpenCoverParser.cs
+++ b/src/ReportGenerator.Core/Parser/OpenCoverParser.cs
@@ -102,14 +102,14 @@ namespace Palmmedia.ReportGenerator.Core.Parser
                 .Where(m => m.Element("ModuleName").Value.Equals(assemblyName))
                 .Elements("Classes")
                 .Elements("Class")
-                .Where(c => !c.Element("FullName").Value.Contains("<")
-                    && c.Attribute("skippedDueTo") == null)
+                .Where(c => c.Attribute("skippedDueTo") == null)
                 .Select(c =>
                     {
                         string fullname = c.Element("FullName").Value;
                         int nestedClassSeparatorIndex = fullname.IndexOf('/');
                         return nestedClassSeparatorIndex > -1 ? fullname.Substring(0, nestedClassSeparatorIndex) : fullname;
                     })
+                .Where(name => !name.Contains("<"))
                 .Distinct()
                 .Where(c => this.ClassFilter.IsElementIncludedInReport(c))
                 .OrderBy(name => name)


### PR DESCRIPTION
ReportGenerator v4.0.0-rc4 (as well as the head of the v4 branch) ignores classes with only async methods, fixed by this PR.  (Might be an echo of #20.)

A coverage report demonstrating this is available here:
https://gist.github.com/petli/024f23c28fc01471d5b51e150a36ac87

Without the fix the `CoverageBugDemo.OnlyAsyncMethods` class is omitted from the report.