### PR TITLE
Use Net Core App 3.0

### DIFF
--- a/src/Deployment/nuget/dotnet-reportgenerator-cli.nuspec
+++ b/src/Deployment/nuget/dotnet-reportgenerator-cli.nuspec
@@ -40,6 +40,16 @@ dotnet reportgenerator [options]</description>
         <dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0-beta0004" />
         <dependency id="Microsoft.NETCore.App" version="2.0.0" exclude="Build,Analyzers" />
       </group>
+      <group targetFramework=".NETCoreApp3.0">
+        <dependency id="McMaster.NETCore.Plugins" version="0.1.1" />
+        <dependency id="Microsoft.Build.Utilities.Core" version="15.8.166" />
+        <dependency id="Microsoft.Extensions.Configuration" version="2.1.1" />
+        <dependency id="Microsoft.Extensions.Configuration.Binder" version="2.1.1" />
+        <dependency id="Microsoft.Extensions.Configuration.CommandLine" version="2.1.1" />
+        <dependency id="Microsoft.Extensions.Configuration.Json" version="2.1.1" />
+        <dependency id="SixLabors.ImageSharp.Drawing" version="1.0.0-beta0004" />
+        <dependency id="Microsoft.NETCore.App" version="3.0.0" exclude="Build,Analyzers" />
+      </group>
     </dependencies>
   </metadata>
   <files>
@@ -53,5 +63,13 @@ dotnet reportgenerator [options]</description>
     <file src="..\..\target\bin\Release\netcoreapp2.0\dotnet-reportgenerator.deps.json" target="lib\netcoreapp2.0\dotnet-reportgenerator.deps.json" />
     <file src="..\..\target\bin\Release\netcoreapp2.0\dotnet-reportgenerator.dll" target="lib\netcoreapp2.0\dotnet-reportgenerator.dll" />
     <file src="..\..\target\bin\Release\netcoreapp2.0\dotnet-reportgenerator.runtimeconfig.json" target="lib\netcoreapp2.0\dotnet-reportgenerator.runtimeconfig.json" />
+    
+    <!-- NetCoreApp3.0 ('lib\netcoreapp3.0' directory) -->
+    <file src="..\..\target\bin\Release\netcoreapp3.0\appsettings.json" target="lib\netcoreapp3.0" />
+    <file src="..\..\target\bin\Release\netcoreapp3.0\ReportGenerator.Core.dll" target="lib\netcoreapp3.0" />
+    <file src="..\..\target\bin\Release\netcoreapp3.0\ReportGenerator.DotnetCorePluginLoader.dll" target="lib\netcoreapp3.0" />
+    <file src="..\..\target\bin\Release\netcoreapp3.0\dotnet-reportgenerator.deps.json" target="lib\netcoreapp3.0\dotnet-reportgenerator.deps.json" />
+    <file src="..\..\target\bin\Release\netcoreapp3.0\dotnet-reportgenerator.dll" target="lib\netcoreapp3.0\dotnet-reportgenerator.dll" />
+    <file src="..\..\target\bin\Release\netcoreapp3.0\dotnet-reportgenerator.runtimeconfig.json" target="lib\netcoreapp3.0\dotnet-reportgenerator.runtimeconfig.json" />
   </files>
 </package>

--- a/src/ReportGenerator.DotnetCliTool/ReportGenerator.DotnetCliTool.csproj
+++ b/src/ReportGenerator.DotnetCliTool/ReportGenerator.DotnetCliTool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
     <ApplicationIcon>ProgramIcon.ico</ApplicationIcon>
     <AssemblyName>dotnet-reportgenerator</AssemblyName>
     <RootNamespace>Palmmedia.ReportGenerator</RootNamespace>

--- a/src/ReportGenerator.DotnetCorePluginLoader/ReportGenerator.DotnetCorePluginLoader.csproj
+++ b/src/ReportGenerator.DotnetCorePluginLoader/ReportGenerator.DotnetCorePluginLoader.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
     <RootNamespace>ReportGenerator.DotnetCorePluginLoader</RootNamespace>
     <AssemblyVersion>4.0.10.0</AssemblyVersion>
     <FileVersion>4.0.10.0</FileVersion>


### PR DESCRIPTION
When building in the CI environment, using .NET Core 3.0 Preview 2, the netcoreapp2.0 target is not available, so it is failed to run when running using `dotnet reportgenerator` tool.