### PR TITLE
Performance improvement- class.js is generated only once.

### DIFF
--- a/src/ReportGenerator.Core/Reporting/Builders/Rendering/HtmlRenderer.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/Rendering/HtmlRenderer.cs
@@ -58,6 +58,11 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders.Rendering
         private static readonly Dictionary<string, string> FileNameByClass = new Dictionary<string, string>();
 
         /// <summary>
+        /// Indicates that JavaScript was generated.
+        /// </summary>
+        private static bool javaScriptGenerated;
+
+        /// <summary>
         /// Indicates that only a summary report is created (no class reports).
         /// </summary>
         private readonly bool onlySummary;
@@ -1082,9 +1087,10 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders.Rendering
         {
             this.SaveReport();
 
-            if (!this.inlineCssAndJavaScript)
+            if (!this.inlineCssAndJavaScript && !javaScriptGenerated)
             {
                 this.SaveJavaScript(targetDirectory);
+                javaScriptGenerated = true;
             }
         }
 


### PR DESCRIPTION
I have to integrate report generator with some legacy project. OpenCover output has about 140MB and 10.000 classes with code coverage. Report generation takes about 274 seconds. The hot point is HtmlRenderer.SaveJavaScript called by SaveClassReport. It is responsible for generating shared class.js file- it could be generated only once. After this simple optimisation report generation takes only 74 seconds.