### PR TITLE
Allow runtime roll-forward

### DIFF
--- a/src/ReportGenerator.Console.NetCore/runtimeconfig.template.json
+++ b/src/ReportGenerator.Console.NetCore/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+  "rollForwardOnNoCandidateFx": 2
+}

--- a/src/ReportGenerator.DotnetCliTool/runtimeconfig.template.json
+++ b/src/ReportGenerator.DotnetCliTool/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+  "rollForwardOnNoCandidateFx": 2
+}

--- a/src/ReportGenerator.DotnetGlobalTool/runtimeconfig.template.json
+++ b/src/ReportGenerator.DotnetGlobalTool/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+  "rollForwardOnNoCandidateFx": 2
+}


### PR DESCRIPTION
Allow roll-forward to .NET Core 3.0 if 2.x is not installed as-per https://github.com/danielpalme/ReportGenerator/pull/205#issuecomment-488252101.

I _think_ I've updated the right projects.