### PR TITLE
expose SummaryResult constructor and HtmlRenderer. fix #243

### DIFF
--- a/src/ReportGenerator.Core/Parser/Analysis/SummaryResult.cs
+++ b/src/ReportGenerator.Core/Parser/Analysis/SummaryResult.cs
@@ -16,7 +16,7 @@ namespace Palmmedia.ReportGenerator.Core.Parser.Analysis
         /// <param name="usedParser">The used parser.</param>
         /// <param name="supportsBranchCoverage">if set to <c>true</c> the used parser supports branch coverage.</param>
         /// <param name="sourceDirectories">The source directories.</param>
-        internal SummaryResult(IReadOnlyCollection<Assembly> assemblies, string usedParser, bool supportsBranchCoverage, IReadOnlyCollection<string> sourceDirectories)
+        public SummaryResult(IReadOnlyCollection<Assembly> assemblies, string usedParser, bool supportsBranchCoverage, IReadOnlyCollection<string> sourceDirectories)
         {
             this.Assemblies = assemblies ?? throw new ArgumentNullException(nameof(assemblies));
             this.UsedParser = usedParser ?? throw new ArgumentNullException(nameof(usedParser));

--- a/src/ReportGenerator.Core/Reporting/Builders/Rendering/HtmlRenderer.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/Rendering/HtmlRenderer.cs
@@ -16,7 +16,7 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders.Rendering
     /// <summary>
     /// HTML report renderer.
     /// </summary>
-    internal class HtmlRenderer : RendererBase, IReportRenderer, IDisposable
+    public class HtmlRenderer : RendererBase, IReportRenderer, IDisposable
     {
         #region HTML Snippets
 
@@ -104,7 +104,7 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders.Rendering
         /// <param name="inlineCssAndJavaScript">if set to <c>true</c> CSS and JavaScript is included into the HTML instead of seperate files.</param>
         /// <param name="cssFileResource">Optional CSS file resource.</param>
         /// <param name="additionalCssFileResource">Optional additional CSS file resource.</param>
-        internal HtmlRenderer(bool onlySummary, bool inlineCssAndJavaScript, string cssFileResource = "custom.css", string additionalCssFileResource = null)
+        public HtmlRenderer(bool onlySummary, bool inlineCssAndJavaScript, string cssFileResource = "custom.css", string additionalCssFileResource = null)
         {
             this.onlySummary = onlySummary;
             this.inlineCssAndJavaScript = inlineCssAndJavaScript;


### PR DESCRIPTION
#243 

> [`internal SummaryResult(IReadOnlyCollection<Assembly> assemblies, string usedParser, bool supportsBranchCoverage, IReadOnlyCollection<string> sourceDirectories)`](https://github.com/danielpalme/ReportGenerator/blob/46bd5f5f9709d29401b3bef849c65f3e2d04c017/src/ReportGenerator.Core/Parser/Analysis/SummaryResult.cs#L19)
>
> I'm trying to create an HTML report using the parsed result with `ReportGenerator.Core`. The class `HtmlReportBuilder` which takes `SummaryResult` as an argument whose constructor isn't exposed.
> 
> ![image](https://user-images.githubusercontent.com/4632805/58073460-3be03f00-7bc0-11e9-87c4-b250240129a8.png)

To create the report I realized we need to expose `HTMLRenderer` as well. Maybe there's a better way to create an HTMLReport from parsed result? If not then I guess we need to expose this.