### PR TITLE
consider nested classes for line coverage

### DIFF
--- a/src/ReportGenerator.Core/Parser/CoberturaParser.cs
+++ b/src/ReportGenerator.Core/Parser/CoberturaParser.cs
@@ -140,7 +140,7 @@ namespace Palmmedia.ReportGenerator.Core.Parser
                 .Elements("class")
                 .Where(c => c.Attribute("name").Value.Equals(className)
                     || c.Attribute("name").Value.StartsWith(className + "$", StringComparison.Ordinal)
-                    || c.Attribute("name").Value.StartsWith(className + "/<", StringComparison.Ordinal))
+                    || c.Attribute("name").Value.StartsWith(className + "/", StringComparison.Ordinal))
                 .Select(c => c.Attribute("filename").Value)
                 .Distinct()
                 .ToArray();
@@ -178,7 +178,7 @@ namespace Palmmedia.ReportGenerator.Core.Parser
                 .Elements("class")
                 .Where(c => c.Attribute("name").Value.Equals(@class.Name)
                             || c.Attribute("name").Value.StartsWith(@class.Name + "$", StringComparison.Ordinal)
-                            || c.Attribute("name").Value.StartsWith(@class.Name + "/<", StringComparison.Ordinal))
+                            || c.Attribute("name").Value.StartsWith(@class.Name + "/", StringComparison.Ordinal))
                 .ToArray();
 
             var lines = classes.Elements("lines")


### PR DESCRIPTION
This fix works locally but I'm not sure of the implications or reasoning for the original filter.

Nested classes seem to be of the form `ParentClass/InnerClass` in the cobertura report.

This shows the result:
![image](https://user-images.githubusercontent.com/95748/58131387-6ab3e080-7bd3-11e9-9f60-e96afbd44ec0.png)
