### PR TITLE
Preserve Found Order

### DIFF
--- a/src/ReportGenerator.Core/ReportConfiguration.cs
+++ b/src/ReportGenerator.Core/ReportConfiguration.cs
@@ -96,9 +96,9 @@ namespace Palmmedia.ReportGenerator.Core
                     {
                         foreach (var file in files)
                         {
-                        	if (seen.Add(f))
-		                    {
-                                this.reportFiles.Add(file);
+                            if (seen.Add(f))
+		            {
+				this.reportFiles.Add(file);
                             }
                         }
                     }

--- a/src/ReportGenerator.Core/ReportConfiguration.cs
+++ b/src/ReportGenerator.Core/ReportConfiguration.cs
@@ -15,7 +15,7 @@ namespace Palmmedia.ReportGenerator.Core
         /// <summary>
         /// The report files.
         /// </summary>
-        private HashSet<string> reportFiles = new HashSet<string>();
+        private List<string> reportFiles = new List<string>();
 
         /// <summary>
         /// The report file pattern that could not be parsed.
@@ -84,6 +84,8 @@ namespace Palmmedia.ReportGenerator.Core
                 throw new ArgumentNullException(nameof(fileFilters));
             }
 
+            var seen = new HashSet<string>();
+
             foreach (var reportFilePattern in reportFilePatterns)
             {
                 try
@@ -94,7 +96,10 @@ namespace Palmmedia.ReportGenerator.Core
                     {
                         foreach (var file in files)
                         {
-                            this.reportFiles.Add(file);
+                        	if (seen.Add(f))
+		                    {
+                                this.reportFiles.Add(file);
+                            }
                         }
                     }
                     else


### PR DESCRIPTION
I think the Hashset use will introduce unexpected behavior for others.   This minor change removes the duplicates, but keeps the order preserved

Disclaimer - I only edited the files via GitHub web interface - so it may not build :-)    But you should get the idea