### PR TITLE
Fix for when clover does not contain package element

### DIFF
--- a/src/ReportGenerator.Core/Parser/CloverParser.cs
+++ b/src/ReportGenerator.Core/Parser/CloverParser.cs
@@ -50,6 +50,11 @@ namespace Palmmedia.ReportGenerator.Core.Parser
             var modules = report.Descendants("package")
               .ToArray();
 
+            if (modules.Length == 0)
+            {
+                modules = report.Descendants("project").ToArray();
+            }
+
             var assemblyNames = modules
                 .Select(m => m.Attribute("name").Value)
                 .Distinct()


### PR DESCRIPTION
For source files that are contained in a single folder, jest doesn't create the `<package>` node in the clover xml and parsing generates no results.

Sample clover xml.
```xml
<?xml version="1.0" encoding="UTF-8"?>
<coverage generated="1566893974275" clover="3.2.0">
  <project timestamp="1566893974275" name="All files">
    <metrics statements="3" coveredstatements="3" conditionals="0" coveredconditionals="0" methods="1" coveredmethods="1" elements="4" coveredelements="4" complexity="0" loc="3" ncloc="3" packages="1" files="1" classes="1"/>
    <file name="app.js" path="D:\jestcoverage\app.js">
      <metrics statements="3" coveredstatements="3" conditionals="0" coveredconditionals="0" methods="1" coveredmethods="1"/>
      <line num="1" count="1" type="stmt"/>
      <line num="2" count="1" type="stmt"/>
      <line num="5" count="1" type="stmt"/>
    </file>
  </project>
</coverage>
```

Fix is to see if there are no `<package>` nodes try to get descendants for `<project>` nodes.