### PR TITLE
Fixing a bug, branch stats reported as blocks

### DIFF
--- a/src/ReportGenerator.Core/Reporting/Builders/LCovSummaryReportBuilder.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/LCovSummaryReportBuilder.cs
@@ -146,19 +146,6 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders
                             reportTextWriter.WriteLine($"LF:{instrumentedLines.ToString(CultureInfo.InvariantCulture)}");
 
                             reportTextWriter.WriteLine("end_of_record");
-
-                            /*
-                             *        Branch coverage summaries are stored in two lines:
-
-         BRF:<number of branches found>
-         BRH:<number of branches hit>
-BRDA: 8,43,0,1
-BRDA: 8,43,1,1
-BRF: 2
-BRH: 2*/
-
-
-
                         }
                     }
                 }


### PR DESCRIPTION
Branches stats should be reported with a PostFix of 'R' according to this https://www.jetbrains.com/help/teamcity/custom-chart.html#Default-Statistics-Values-Provided-by-TeamCity