### PR TITLE
Only write data urls in combined CSS for inline HtmlRenderers

### DIFF
--- a/src/ReportGenerator.Core/Reporting/Builders/Rendering/HtmlRenderer.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/Rendering/HtmlRenderer.cs
@@ -1344,14 +1344,31 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders.Rendering
         private Stream GetCombinedCss()
         {
             var ms = new MemoryStream();
+            var lineBreak = Encoding.UTF8.GetBytes(Environment.NewLine);
+
+            void CopyWithFilteredUrls(Stream s)
+            {
+                if (!this.inlineCssAndJavaScript)
+                {
+                    s.CopyTo(ms);
+                    return;
+                }
+
+                using (var reader = new StreamReader(s))
+                {
+                    var contents = Regex.Replace(reader.ReadToEnd(), @"url\(icon_.+.svg\),\s", string.Empty);
+                    var bytes = Encoding.UTF8.GetBytes(contents);
+                    ms.Write(bytes, 0, bytes.Length);
+                    ms.Write(lineBreak, 0, lineBreak.Length);
+                }
+            }
 
             using (Stream stream = typeof(HtmlRenderer).Assembly.GetManifestResourceStream(
                 $"Palmmedia.ReportGenerator.Core.Reporting.Builders.Rendering.resources.{this.cssFileResource}"))
             {
-                stream.CopyTo(ms);
+                CopyWithFilteredUrls(stream);
             }
 
-            byte[] lineBreak = Encoding.UTF8.GetBytes(Environment.NewLine);
             ms.Write(lineBreak, 0, lineBreak.Length);
             ms.Write(lineBreak, 0, lineBreak.Length);
 
@@ -1363,7 +1380,7 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders.Rendering
                 using (Stream stream = typeof(HtmlRenderer).Assembly.GetManifestResourceStream(
                     $"Palmmedia.ReportGenerator.Core.Reporting.Builders.Rendering.resources.{this.additionalCssFileResource}"))
                 {
-                    stream.CopyTo(ms);
+                    CopyWithFilteredUrls(stream);
                 }
 
                 ms.Write(lineBreak, 0, lineBreak.Length);


### PR DESCRIPTION
I noticed I was getting some 404's when using the inline html formats that were coming from `background-image: url()` elements like [this one](https://github.com/danielpalme/ReportGenerator/blob/d63c8c22da01955281c5cabf95966a68cadd36ea/src/ReportGenerator.Core/Reporting/Builders/Rendering/resources/custom-azurepipelines.css#L268) . This strips them out when getting the combined css for an inline HTML report.

Another possibility is to remove the non-inlined version of these background-image elements; 
they appear to be same data as the uris, as they're used to write out the images in non-inline reports:

https://github.com/danielpalme/ReportGenerator/blob/d63c8c22da01955281c5cabf95966a68cadd36ea/src/ReportGenerator.Core/Reporting/Builders/Rendering/HtmlRenderer.cs#L1305-L1318


But if I know my webdev tropes they're probably there for a reason 🙃 