### PR TITLE
Fix class-level branch coverage for OpenCover reports

### DIFF
--- a/src/ReportGenerator.Core/Parser/OpenCoverParser.cs
+++ b/src/ReportGenerator.Core/Parser/OpenCoverParser.cs
@@ -467,7 +467,7 @@ namespace Palmmedia.ReportGenerator.Core.Parser
                 {
                     if (branches.TryGetValue(identifier, out var found))
                     {
-                        found.BranchVisits += found.BranchVisits;
+                        found.BranchVisits += vc;
                     }
                     else
                     {


### PR DESCRIPTION
Use the correct variable for visit count when adding visits to an existing Branch object.