### PR TITLE
Add support for reading report arguments from .netconfig

### DIFF
--- a/src/ReportGenerator.Core.Test/ReportConfigurationBuilderTest.cs
+++ b/src/ReportGenerator.Core.Test/ReportConfigurationBuilderTest.cs
@@ -1,5 +1,7 @@
+﻿using System;
 using System.IO;
 using System.Linq;
+using DotNetConfig;
 using Palmmedia.ReportGenerator.Core.Logging;
 using Xunit;
 
@@ -10,16 +12,20 @@ namespace Palmmedia.ReportGenerator.Core.Test
     /// to contain all ReportConfigurationBuilder Unit Tests
     /// </summary>
     [Collection("FileManager")]
-    public class ReportConfigurationBuilderTest
+    public class ReportConfigurationBuilderTest : IDisposable
     {
         private static readonly string ReportPath = Path.Combine(FileManager.GetCSharpReportDirectory(), "OpenCover.xml");
 
         private ReportConfigurationBuilder reportConfigurationBuilder;
+        private string currentDir;
 
         public ReportConfigurationBuilderTest()
         {
             this.reportConfigurationBuilder = new ReportConfigurationBuilder();
+            this.currentDir = Directory.GetCurrentDirectory();
         }
+
+        public void Dispose() => Directory.SetCurrentDirectory(this.currentDir);
 
         [Fact]
         public void InitWithNamedArguments_OldFilters_AllPropertiesApplied()
@@ -69,6 +75,93 @@ namespace Palmmedia.ReportGenerator.Core.Test
             Assert.NotNull(configuration.ReportFiles);
             Assert.NotNull(configuration.AssemblyFilters);
             Assert.NotNull(configuration.ClassFilters);
+        }
+
+
+        [Fact]
+        public void ConfigProvidesMissingArguments()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(dir);
+            var config = Config.Build(dir).GetSection(ReportConfigurationBuilder.SectionName);
+
+            config.SetString("reports", ReportPath);
+            config.SetString("targetdir", "C:\\temp");
+            config.SetString("reporttype", "Latex");
+            config.SetString("assemblyfilters", "+Test;-Test");
+            config.SetString("classfilters", "+Test2;-Test2");
+            config.SetString("verbosity", VerbosityLevel.Info.ToString());
+
+            Directory.SetCurrentDirectory(dir);
+
+            string[] namedArguments = new string[0];
+
+            var configuration = this.reportConfigurationBuilder.Create(namedArguments);
+
+            Assert.True(configuration.ReportFiles.Contains(ReportPath), "ReportPath does not exist in ReportFiles.");
+            Assert.Equal("C:\\temp", configuration.TargetDirectory);
+            Assert.True(configuration.ReportTypes.Contains("Latex"), "Wrong report type applied.");
+            Assert.True(configuration.AssemblyFilters.Contains("+Test"), "AssemblyFilters does not exist in ReportFiles.");
+            Assert.True(configuration.ClassFilters.Contains("+Test2"), "ClassFilters does not exist in ReportFiles.");
+            Assert.True(configuration.AssemblyFilters.Contains("-Test"), "AssemblyFilters does not exist in ReportFiles.");
+            Assert.True(configuration.ClassFilters.Contains("-Test2"), "ClassFilters does not exist in ReportFiles.");
+            Assert.NotNull(configuration.ReportFiles);
+            Assert.NotNull(configuration.AssemblyFilters);
+            Assert.NotNull(configuration.ClassFilters);
+        }
+
+        [Fact]
+        public void ConfigProvidesMultiValuedSettings()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(dir);
+            var config = Config.Build(dir).GetSection(ReportConfigurationBuilder.SectionName);
+
+            config.SetString("reports", ReportPath);
+
+            config.AddString("reporttype", "Latex");
+            config.AddString("reporttype", "Html");
+
+            config.AddString("assemblyfilter", "+Test");
+            config.AddString("assemblyfilter", "-Test");
+
+            config.AddString("classfilter", "+Test2");
+            config.AddString("classfilter", "-Test2");
+
+            config.AddString("filefilter", "+cs");
+            config.AddString("filefilter", "-vb");
+
+            config.AddString("sourcedir", "src");
+            config.AddString("sourcedir", "test");
+
+            config.AddString("plugin", "xunit");
+            config.AddString("plugin", "moq");
+
+            Directory.SetCurrentDirectory(dir);
+
+            string[] namedArguments = new string[0];
+
+            var configuration = this.reportConfigurationBuilder.Create(namedArguments);
+
+            Assert.Contains(ReportPath, configuration.ReportFiles);
+
+            Assert.Contains("Latex", configuration.ReportTypes);
+            Assert.Contains("Html", configuration.ReportTypes);
+
+            Assert.Contains("+Test", configuration.AssemblyFilters);
+            Assert.Contains("-Test", configuration.AssemblyFilters);
+
+            Assert.Contains("+Test2", configuration.ClassFilters);
+            Assert.Contains("-Test2", configuration.ClassFilters);
+
+            Assert.Contains("+cs", configuration.FileFilters);
+            Assert.Contains("-vb", configuration.FileFilters);
+
+            Assert.Contains("src", configuration.SourceDirectories);
+            Assert.Contains("test", configuration.SourceDirectories);
+
+            Assert.Contains("xunit", configuration.Plugins);
+            Assert.Contains("moq", configuration.Plugins);
         }
     }
 }

--- a/src/ReportGenerator.Core/ReportConfigurationBuilder.cs
+++ b/src/ReportGenerator.Core/ReportConfigurationBuilder.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
+using DotNetConfig;
 
 namespace Palmmedia.ReportGenerator.Core
 {
@@ -11,6 +13,11 @@ namespace Palmmedia.ReportGenerator.Core
     public class ReportConfigurationBuilder
     {
         /// <summary>
+        /// Name of the configuration section in a .netconfig file.
+        /// </summary>
+        public const string SectionName = "ReportGenerator";
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ReportConfiguration"/> class.
         /// </summary>
         /// <param name="cliArguments">The command line arguments stored as key value pairs.</param>
@@ -18,16 +25,17 @@ namespace Palmmedia.ReportGenerator.Core
         public ReportConfiguration Create(Dictionary<string, string> cliArguments)
         {
             var namedArguments = new Dictionary<string, string>(cliArguments, StringComparer.OrdinalIgnoreCase);
+            var config = Config.Build().GetSection(SectionName);
 
-            var reportFilePatterns = new string[] { };
-            string targetDirectory = string.Empty;
-            var sourceDirectories = new string[] { };
+            var reportFilePatterns = Array.Empty<string>();
+            var targetDirectory = string.Empty;
+            var sourceDirectories = Array.Empty<string>();
             string historyDirectory = null;
-            var reportTypes = new string[] { };
-            var plugins = new string[] { };
-            var assemblyFilters = new string[] { };
-            var classFilters = new string[] { };
-            var fileFilters = new string[] { };
+            var reportTypes = Array.Empty<string>();
+            var plugins = Array.Empty<string>();
+            var assemblyFilters = Array.Empty<string>();
+            var classFilters = Array.Empty<string>();
+            var fileFilters = Array.Empty<string>();
             string verbosityLevel = null;
             string title = null;
             string tag = null;
@@ -38,8 +46,24 @@ namespace Palmmedia.ReportGenerator.Core
             {
                 reportFilePatterns = value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
             }
+            else if (config.TryGetString("reports", out value))
+            {
+                reportFilePatterns = value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            }
+            else
+            {
+                reportFilePatterns = config
+                    .GetAll("report")
+                    .Select(x => x.RawValue)
+                    .Where(x => !string.IsNullOrEmpty(x))
+                    .ToArray();
+            }
 
             if (namedArguments.TryGetValue("TARGETDIR", out value))
+            {
+                targetDirectory = value;
+            }
+            else if (config.TryGetString("targetdir", out value))
             {
                 targetDirectory = value;
             }
@@ -48,8 +72,24 @@ namespace Palmmedia.ReportGenerator.Core
             {
                 sourceDirectories = value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
             }
+            else if (config.TryGetString("sourcedirs", out value))
+            {
+                sourceDirectories = value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            }
+            else
+            {
+                sourceDirectories = config
+                    .GetAll("sourcedir")
+                    .Select(x => x.RawValue)
+                    .Where(x => !string.IsNullOrEmpty(x))
+                    .ToArray();
+            }
 
             if (namedArguments.TryGetValue("HISTORYDIR", out value))
+            {
+                historyDirectory = value;
+            }
+            else if (config.TryGetString("historydir", out value))
             {
                 historyDirectory = value;
             }
@@ -62,10 +102,34 @@ namespace Palmmedia.ReportGenerator.Core
             {
                 reportTypes = new[] { value };
             }
+            else if (config.TryGetString("reporttypes", out value))
+            {
+                reportTypes = value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            }
+            else
+            {
+                reportTypes = config
+                    .GetAll("reporttype")
+                    .Select(x => x.RawValue)
+                    .Where(x => !string.IsNullOrEmpty(x))
+                    .ToArray();
+            }
 
             if (namedArguments.TryGetValue("PLUGINS", out value))
             {
                 plugins = value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            }
+            else if (config.TryGetString("plugins", out value))
+            {
+                plugins = value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            }
+            else
+            {
+                plugins = config
+                    .GetAll("plugin")
+                    .Select(x => x.RawValue)
+                    .Where(x => !string.IsNullOrEmpty(x))
+                    .ToArray();
             }
 
             if (namedArguments.TryGetValue("ASSEMBLYFILTERS", out value))
@@ -76,18 +140,58 @@ namespace Palmmedia.ReportGenerator.Core
             {
                 assemblyFilters = value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
             }
+            else if (config.TryGetString("assemblyfilters", out value))
+            {
+                assemblyFilters = value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            }
+            else
+            {
+                assemblyFilters = config
+                    .GetAll("assemblyfilter")
+                    .Select(x => x.RawValue)
+                    .Where(x => !string.IsNullOrEmpty(x))
+                    .ToArray();
+            }
 
             if (namedArguments.TryGetValue("CLASSFILTERS", out value))
             {
                 classFilters = value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            }
+            else if (config.TryGetString("classfilters", out value))
+            {
+                classFilters = value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            }
+            else
+            {
+                classFilters = config
+                    .GetAll("classfilter")
+                    .Select(x => x.RawValue)
+                    .Where(x => !string.IsNullOrEmpty(x))
+                    .ToArray();
             }
 
             if (namedArguments.TryGetValue("FILEFILTERS", out value))
             {
                 fileFilters = value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
             }
+            else if (config.TryGetString("filefilters", out value))
+            {
+                fileFilters = value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            }
+            else
+            {
+                fileFilters = config
+                    .GetAll("filefilter")
+                    .Select(x => x.RawValue)
+                    .Where(x => !string.IsNullOrEmpty(x))
+                    .ToArray();
+            }
 
             if (namedArguments.TryGetValue("VERBOSITY", out value))
+            {
+                verbosityLevel = value;
+            }
+            else if (config.TryGetString("verbosity", out value))
             {
                 verbosityLevel = value;
             }
@@ -96,8 +200,16 @@ namespace Palmmedia.ReportGenerator.Core
             {
                 title = value;
             }
+            else if (config.TryGetString("title", out value))
+            {
+                title = value;
+            }
 
             if (namedArguments.TryGetValue("TAG", out value))
+            {
+                tag = value;
+            }
+            else if (config.TryGetString("tag", out value))
             {
                 tag = value;
             }

--- a/src/ReportGenerator.Core/ReportGenerator.Core.csproj
+++ b/src/ReportGenerator.Core/ReportGenerator.Core.csproj
@@ -78,6 +78,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0008" />
+    <PackageReference Include="DotNetConfig" Version="1.0.0-beta" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
The http://dotnetconfig.org/ format allows unifying configuration with
other .NET core tools, making it easier to maintain multiple tool settings
in a centralized fashion.

By leveraging the format, ReportGenerator gains:

* Simplified command line args in CI scripts (just run without parameters
  most of the time)
* Support for hierarchical configurations
* Standard way of updating and managing those configurations, via the
  `dotnet config` tool, such as `dotnet config --add reportgenerator.reporttype Html`

The configuration is shared uniformly between the CLI and MSBuild task, for
consistency. Updated the documentation too to showcase the new functionality.