### PR TITLE
Improve reliability and logging for MSBuild tests

### DIFF
--- a/src/ReportGenerator.Core.Test/FileManager.cs
+++ b/src/ReportGenerator.Core.Test/FileManager.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Linq;
+using System.Reflection;
 using Xunit;
 
 namespace Palmmedia.ReportGenerator.Core.Test
@@ -88,21 +89,12 @@ namespace Palmmedia.ReportGenerator.Core.Test
             return filesDirectory;
         }
 
-        internal static string GetTestDirectory()
-        {
-            var currentDirectory = new DirectoryInfo(System.Reflection.Assembly.GetExecutingAssembly().Location);
-
-            while (true)
-            {
-                currentDirectory = currentDirectory.Parent;
-                string directory = Path.Combine(currentDirectory.FullName, "ReportGenerator.Core.Test");
-
-                if (Directory.Exists(directory))
-                {
-                    return directory;
-                }
-            }
-        }
+        internal static string GetTestDirectory() => Assembly
+            .GetExecutingAssembly()
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .Where(attr => attr.Key == "ProjectDirectory")
+            .Select(attr => attr.Value)
+            .FirstOrDefault() ?? Directory.GetCurrentDirectory() + @"..\..";
     }
 
     [CollectionDefinition("FileManager")]

--- a/src/ReportGenerator.Core.Test/MsBuildTest.cs
+++ b/src/ReportGenerator.Core.Test/MsBuildTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.IO;
 using Xunit;
 
@@ -30,16 +31,19 @@ namespace Palmmedia.ReportGenerator.Core.Test
                 {
                     found = true;
 
+                    var log = Path.Combine(
+                        Environment.GetEnvironmentVariable("BUILD_ARTIFACTSTAGINGDIRECTORY") ?? FileManager.GetTestDirectory(), 
+                        nameof(ExecuteMSBuildScript_NetFull) + ".binlog");
                     var processStartInfo = new ProcessStartInfo(
                         paths[i],
-                        $"MsBuildTestScript.proj /p:Configuration={configuration}")
+                        $"MsBuildTestScript.proj /p:Configuration={configuration} /bl:{log}")
                     {
                         WorkingDirectory = FileManager.GetTestDirectory(),
                         RedirectStandardOutput = true
                     };
 
                     var process = Process.Start(processStartInfo);
-                    process.WaitForExit();
+                    Assert.True(process.WaitForExit(5000));
 
                     Assert.True(0 == process.ExitCode, process.StandardOutput.ReadToEnd());
 
@@ -59,16 +63,19 @@ namespace Palmmedia.ReportGenerator.Core.Test
             configuration = "Debug";
 #endif
 
+            var log = Path.Combine(
+                Environment.GetEnvironmentVariable("BUILD_ARTIFACTSTAGINGDIRECTORY") ?? FileManager.GetTestDirectory(),
+                nameof(ExecuteMSBuildScript_NetCore) + ".binlog");
             var processStartInfo = new ProcessStartInfo(
                 "dotnet",
-                $"msbuild MsBuildTestScript_NetCore.proj /p:Configuration={configuration}")
+                $"msbuild MsBuildTestScript_NetCore.proj /p:Configuration={configuration} /bl:{log}")
             {
                 WorkingDirectory = FileManager.GetTestDirectory(),
                 RedirectStandardOutput = true
             };
 
             var process = Process.Start(processStartInfo);
-            process.WaitForExit();
+            Assert.True(process.WaitForExit(5000));
 
             Assert.True(0 == process.ExitCode, process.StandardOutput.ReadToEnd());
         }

--- a/src/ReportGenerator.Core.Test/ReportGenerator.Core.Test.csproj
+++ b/src/ReportGenerator.Core.Test/ReportGenerator.Core.Test.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Palmmedia.ReportGenerator.Core.Test</RootNamespace>
     <AssemblyVersion>4.6.5.0</AssemblyVersion>
     <FileVersion>4.6.5.0</FileVersion>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   
   <ItemGroup>
@@ -51,6 +52,13 @@
     <None Update="Common\Encodings\utf8_bom.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>ProjectDirectory</_Parameter1>
+      <_Parameter2>$(MSBuildProjectDirectory)</_Parameter2>
+    </AssemblyAttribute>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Instead of directory probing, just use assembly metadata to persist the
project directory where the test project files are. Quicker and also
more reliable.

Also, always generate binlogs for MSBuild tests, for troubleshooting
purposes.