### PR TITLE
Update all calls to XDocument.Save to use an XmlTextWriter without a UTF-8 BOM encoding.

### DIFF
--- a/src/ReportGenerator.Core/Reporting/Builders/CloverReportBuilder.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/CloverReportBuilder.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
+using System.Xml;
 using System.Xml.Linq;
 using Palmmedia.ReportGenerator.Core.Logging;
 using Palmmedia.ReportGenerator.Core.Parser.Analysis;
@@ -386,7 +388,10 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders
 
             Logger.InfoFormat(Resources.WritingReportFile, targetPath);
 
-            result.Save(targetPath);
+            using (var writer = new XmlTextWriter(targetPath, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
+            {
+                result.Save(writer);
+            }
         }
     }
 }

--- a/src/ReportGenerator.Core/Reporting/Builders/CoberturaReportBuilder.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/CoberturaReportBuilder.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
+using System.Xml;
 using System.Xml.Linq;
 using Palmmedia.ReportGenerator.Core.Logging;
 using Palmmedia.ReportGenerator.Core.Parser.Analysis;
@@ -233,7 +235,10 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders
 
             Logger.InfoFormat(Resources.WritingReportFile, targetPath);
 
-            result.Save(targetPath);
+            using (var writer = new XmlTextWriter(targetPath, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
+            {
+                result.Save(writer);
+            }
         }
 
         /// <summary>

--- a/src/ReportGenerator.Core/Reporting/Builders/SonarQubeBuilder.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/SonarQubeBuilder.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
+using System.Xml;
 using System.Xml.Linq;
 using Palmmedia.ReportGenerator.Core.Logging;
 using Palmmedia.ReportGenerator.Core.Parser.Analysis;
@@ -91,7 +93,10 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders
 
             Logger.InfoFormat(Resources.WritingReportFile, targetPath);
 
-            this.document.Save(targetPath);
+            using (var writer = new XmlTextWriter(targetPath, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
+            {
+                this.document.Save(writer);
+            }
         }
 
         /// <summary>

--- a/src/ReportGenerator.Core/Reporting/Builders/XmlReportBuilder.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/XmlReportBuilder.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
+using System.Xml;
 using System.Xml.Linq;
 using Palmmedia.ReportGenerator.Core.Logging;
 using Palmmedia.ReportGenerator.Core.Parser.Analysis;
@@ -149,7 +151,10 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders
 
             Logger.InfoFormat(Resources.WritingReportFile, targetPath);
 
-            result.Save(targetPath);
+            using (var writer = new XmlTextWriter(targetPath, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
+            {
+                result.Save(writer);
+            }
         }
 
         /// <summary>

--- a/src/ReportGenerator.Core/Reporting/Builders/XmlSummaryReportBuilder.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/XmlSummaryReportBuilder.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
+using System.Xml;
 using System.Xml.Linq;
 using Palmmedia.ReportGenerator.Core.Logging;
 using Palmmedia.ReportGenerator.Core.Parser.Analysis;
@@ -158,7 +160,10 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders
 
             Logger.InfoFormat(Resources.WritingReportFile, targetPath);
 
-            result.Save(targetPath);
+            using (var writer = new XmlTextWriter(targetPath, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
+            {
+                result.Save(writer);
+            }
         }
     }
 }

--- a/src/ReportGenerator.Core/Reporting/History/HistoryReportGenerator.cs
+++ b/src/ReportGenerator.Core/Reporting/History/HistoryReportGenerator.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Text;
+using System.Xml;
 using System.Xml.Linq;
 using Palmmedia.ReportGenerator.Core.Common;
 using Palmmedia.ReportGenerator.Core.Logging;
@@ -87,7 +89,10 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.History
             {
                 using (var stream = new MemoryStream())
                 {
-                    document.Save(stream);
+                    using (var writer = new XmlTextWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
+                    {
+                        document.Save(writer);
+                    }
                     stream.Position = 0;
                     this.historyStorage.SaveFile(stream, fileName);
                 }


### PR DESCRIPTION
Attempt at fixing https://github.com/danielpalme/ReportGenerator/issues/380, if the issue is valid for the project :)

cc @danielpalme