### PR TITLE
fix: clean up directory separators before path combine

### DIFF
--- a/src/ReportGenerator.Core/Parser/Preprocessing/CoberturaReportPreprocessor.cs
+++ b/src/ReportGenerator.Core/Parser/Preprocessing/CoberturaReportPreprocessor.cs
@@ -71,9 +71,9 @@ namespace Palmmedia.ReportGenerator.Core.Parser.Preprocessing
                         continue;
                     }
 
-                    string path = Path.Combine(sources[0], fileNameAttribute.Value)
-                        .Replace('\\', Path.DirectorySeparatorChar)
-                        .Replace('/', Path.DirectorySeparatorChar);
+                    string sourcePath = sources[0].Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
+                    string fileName = fileNameAttribute.Value.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
+                    string path = Path.Combine(sourcePath, fileName);
                     fileNameAttribute.Value = path;
                 }
             }
@@ -90,9 +90,9 @@ namespace Palmmedia.ReportGenerator.Core.Parser.Preprocessing
 
                     foreach (var source in sources)
                     {
-                        string path = Path.Combine(source, fileNameAttribute.Value)
-                            .Replace('\\', Path.DirectorySeparatorChar)
-                            .Replace('/', Path.DirectorySeparatorChar);
+                        string sourcePath = source.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
+                        string fileName = fileNameAttribute.Value.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
+                        string path = Path.Combine(sourcePath, fileName);
 
                         if (File.Exists(path))
                         {


### PR DESCRIPTION
Fixes the issue of generating double directory separators from cobertura reports, when switching OS between coverage data and report generation.

Problem exists when the cobertura report is generated on a windows machine, but ReportGenerator runs on linux machine.
- the cobertura coverage result contains file paths windows style e.g. 'C:\builds\src\Download\', 'Test.cs'
- calling Path.Combine on a linux system afterwards results in 'C:\builds\src\Download\/Test.cs'
- which gets edited with Replace to 'C:/builds/src/Download//Test.cs'

Adapting the path strings to the current OS before Path.Combine fixes this issue.
