### PR TITLE
Fix issues with handling of multiple assemblies with the same name

### DIFF
--- a/src/ReportGenerator.Core/Parser/DynamicCodeCoverageParser.cs
+++ b/src/ReportGenerator.Core/Parser/DynamicCodeCoverageParser.cs
@@ -83,7 +83,7 @@ namespace Palmmedia.ReportGenerator.Core.Parser
         /// <returns>The <see cref="Assembly"/>.</returns>
         private Assembly ProcessAssembly(XElement module)
         {
-            string assemblyName = module.Attribute("name").Value;
+            string assemblyName = module.Attribute("name").Value + "_" + module.Attribute("id").Value;
 
             Logger.DebugFormat(Resources.CurrentAssembly, assemblyName);
 
@@ -187,7 +187,9 @@ namespace Palmmedia.ReportGenerator.Core.Parser
             var linesOfFile = methods
                 .Elements("ranges")
                 .Elements("range")
+                .Where(r => r.Attribute("source_id").Value == fileId)
                 .Where(l => l.Attribute("start_line").Value != "15732480")
+                .Distinct()
                 .Select(l => new
                 {
                     LineNumberStart = int.Parse(l.Attribute("start_line").Value, CultureInfo.InvariantCulture),

--- a/src/ReportGenerator.Core/Reporting/Builders/Rendering/HtmlRenderer.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/Rendering/HtmlRenderer.cs
@@ -299,7 +299,7 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders.Rendering
                             codeElement.FirstLine,
                             codeElement.CoverageQuota.HasValue ? coverageRounded.ToString() : "undefined",
                             codeElement.CoverageQuota.HasValue ? ReportResources.Coverage2 + " " + codeElement.CoverageQuota.Value.ToString(CultureInfo.InvariantCulture) + "% - " : string.Empty,
-                            WebUtility.HtmlEncode(codeElement.Name),
+                            WebUtility.HtmlEncode($"File {item.Key} => " + codeElement.Name),
                             codeElement.CodeElementType == CodeElementType.Method ? "cube" : "wrench");
                     }
                 }
@@ -626,7 +626,8 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders.Rendering
         /// <param name="files">The files.</param>
         public void KeyValueRow(string key, IEnumerable<string> files)
         {
-            string value = string.Join("<br />", files.Select(v => string.Format(CultureInfo.InvariantCulture, "<a href=\"#{0}\" class=\"navigatetohash\">{1}</a>", WebUtility.HtmlEncode(StringHelper.ReplaceNonLetterChars(v)), WebUtility.HtmlEncode(v))));
+            int fileIndex = 0;
+            string value = string.Join("<br />", files.Select(v => string.Format(CultureInfo.InvariantCulture, "<a href=\"#{0}\" class=\"navigatetohash\">{1}</a>", WebUtility.HtmlEncode(StringHelper.ReplaceNonLetterChars(v)), WebUtility.HtmlEncode($"File {fileIndex++}: " + v))));
 
             this.reportTextWriter.WriteLine(
                 "<tr><th>{0}</th><td>{1}</td></tr>",
@@ -686,11 +687,11 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders.Rendering
                             WebUtility.HtmlEncode(methodMetric.FullName),
                             fileIndex,
                             methodMetric.Line,
-                            WebUtility.HtmlEncode(methodMetric.ShortName));
+                            WebUtility.HtmlEncode($"File {fileIndex} => " + methodMetric.ShortName));
                     }
                     else
                     {
-                        this.reportTextWriter.Write("<td title=\"{0}\">{1}</td>", WebUtility.HtmlEncode(methodMetric.FullName), WebUtility.HtmlEncode(methodMetric.ShortName));
+                        this.reportTextWriter.Write("<td title=\"{0}\">{1}</td>", WebUtility.HtmlEncode(methodMetric.FullName), WebUtility.HtmlEncode(file.Path + " => " + methodMetric.ShortName));
                     }
 
                     foreach (var metric in metrics)


### PR DESCRIPTION
Thanks for creating this great tool!

Regarding this PR: In our scenarios, we have one DLL that built separately for x86 and x64. Then we run our tests against this DLL on x86 machines and x64 machines separately, also collect the code coverage data using VSTest.console.exe from Visual Studio. Eventually, we merge all the code coverage files into one file. This resulted in 2 modules (actually same module for different architectures) with the same assembly name with different IDs in the merged file.

Although ReportGenerator is able to handle multiple assemblies, but it expects the assemblies' name to be unique. Our data fails this expectation, and the report generated by ReportGenerator is mixing the coverage data from different modules together. 

Another issue is that, when multiple source files are invoked in a method of the same class, that method is repeated multiple times on the class coverage page. It is not very convenient to understand which file is associated with those method entries. 

This PR tries to resolve above issues.