### PR TITLE
[Security] Fix CVE-2021-26701 (Remote Code Execution Vulnerability) and update DotNetConfig to RTM

### DIFF
--- a/src/ReportGenerator.Core/ReportGenerator.Core.csproj
+++ b/src/ReportGenerator.Core/ReportGenerator.Core.csproj
@@ -78,7 +78,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta11" />
-    <PackageReference Include="DotNetConfig" Version="1.0.0-rc.2" />
+    <!-- System.Text.Encodings.Web 5.0.1+ for  CVE-2021-26701  - see https://github.com/dotnet/runtime/issues/49377 -->
+    <PackageReference Include="System.Text.Encodings.Web" Version="5.0.*" />
+    <PackageReference Include="DotNetConfig" Version="1.0.*" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
See https://github.com/dotnet/runtime/issues/49377 - Microsoft Security Advisory CVE-2021-26701 | .NET Core Remote Code Execution Vulnerability 


5.0.0 was used for System.Text.Encodings.Web, updated to 5.0.1

Also updated DotNetConfig package to a non-preview version

Needed for dotnet-reportgenerator-globaltool


See also report Nexus IQ (sorry no public link)

![image](https://user-images.githubusercontent.com/5808377/125100067-fac98280-e0d8-11eb-952d-a4d6df631a95.png)

![image](https://user-images.githubusercontent.com/5808377/125100165-15036080-e0d9-11eb-979b-1224b6492c23.png)
