### PR TITLE
Improve text of FailedReportFilePattern

### DIFF
--- a/src/ReportGenerator.Core/Properties/Resources.resx
+++ b/src/ReportGenerator.Core/Properties/Resources.resx
@@ -199,7 +199,7 @@
     <value>The report file '{0}' is invalid. File does not exist (Full path: '{1}').</value>
   </data>
   <data name="FailedReportFilePattern" xml:space="preserve">
-    <value>The report file pattern '{0}' is invalid. No matching files found.</value>
+    <value>The report file pattern '{0}' found no matching files.</value>
   </data>
   <data name="FailedToInstantiatePlugin" xml:space="preserve">
     <value>Failed to instantiate plugin class '{0}'.</value>


### PR DESCRIPTION
The text "The report file pattern '{0}' is invalid" is confusing. The pattern itself isn't invalid. 

Example:

     -reports:**/*cobertura*.xml;**/*opencover*.xml;


Will give now: `The report file pattern "**/*cobertura*.xml ' is invalid` - which is confusing 

note: This a generic template and we let the user decide if it uses opencover or cobertura