### PR TITLE
color change of header rows for dark mode preference users

### DIFF
--- a/src/ReportGenerator.Core/Reporting/Builders/Rendering/resources/custom.css
+++ b/src/ReportGenerator.Core/Reporting/Builders/Rendering/resources/custom.css
@@ -409,6 +409,10 @@ code { font-family: Consolas, monospace; font-size: 0.9em; }
             border: solid 1px #3B3A39;
         }
 
+        .overview tr.namespace th {
+            background-color: #444;
+        }
+
         .overview thead th {
             background-color: #444;
         }


### PR DESCRIPTION
Let me start out by saying that I love this tool.

I've recently started using it to generate reports on code coverage. One thing stood out to me though. When dark mode preference is set in the browser and the report loads in dark mode, the header rows for namespaces are a really light color. (I think it was just missed probably) like in this screenshot.
![before-style-fix](https://user-images.githubusercontent.com/7481591/140593258-a8a06115-f4df-46bc-b725-45f71c6c33e2.png)
. 

With my change I believe I have fixed the issue
![after_style_fix](https://user-images.githubusercontent.com/7481591/140593273-e09bed14-8f81-4959-9fe6-a58e0b752af7.png)
.

If you could take a look at this, I would greatly appreciate it. And I'm open to any suggestions on what else I can do.

Thanks!