### PR TITLE
Generate text reports without UTF-8 BOM

### DIFF
--- a/src/ReportGenerator.Core/Reporting/Builders/CsvSummaryReportBuilder.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/CsvSummaryReportBuilder.cs
@@ -81,7 +81,7 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders
 
             Logger.InfoFormat(Resources.WritingReportFile, targetPath);
 
-            using (var reportTextWriter = new StreamWriter(new FileStream(targetPath, FileMode.Create), Encoding.UTF8))
+            using (var reportTextWriter = File.CreateText(targetPath))
             {
                 reportTextWriter.WriteLine(ReportResources.Summary);
                 reportTextWriter.WriteLine(

--- a/src/ReportGenerator.Core/Reporting/Builders/LCovSummaryReportBuilder.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/LCovSummaryReportBuilder.cs
@@ -80,7 +80,7 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders
 
             Logger.InfoFormat(Resources.WritingReportFile, targetPath);
 
-            using (var reportTextWriter = new StreamWriter(new FileStream(targetPath, FileMode.Create), Encoding.UTF8))
+            using (var reportTextWriter = File.CreateText(targetPath))
             {
                 reportTextWriter.WriteLine("TN:");
                 long branchCounter = 0;

--- a/src/ReportGenerator.Core/Reporting/Builders/MarkdownDeltaSummaryReportBuilder.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/MarkdownDeltaSummaryReportBuilder.cs
@@ -92,7 +92,7 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders
 
             Logger.InfoFormat(Resources.WritingReportFile, targetPath);
 
-            using (var reportTextWriter = new StreamWriter(new FileStream(targetPath, FileMode.Create), Encoding.UTF8))
+            using (var reportTextWriter = File.CreateText(targetPath))
             {
                 HistoricCoverage previous = historicCoverages[0];
                 HistoricCoverage current = historicCoverages[1];

--- a/src/ReportGenerator.Core/Reporting/Builders/MarkdownSummaryReportBuilder.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/MarkdownSummaryReportBuilder.cs
@@ -81,7 +81,7 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders
 
             Logger.InfoFormat(Resources.WritingReportFile, targetPath);
 
-            using (var reportTextWriter = new StreamWriter(new FileStream(targetPath, FileMode.Create), Encoding.UTF8))
+            using (var reportTextWriter = File.CreateText(targetPath))
             {
                 reportTextWriter.WriteLine("# {0}", ReportResources.Summary);
                 reportTextWriter.WriteLine("|||");

--- a/src/ReportGenerator.Core/Reporting/Builders/TextDeltaSummaryReportBuilder.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/TextDeltaSummaryReportBuilder.cs
@@ -92,7 +92,7 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders
 
             Logger.InfoFormat(Resources.WritingReportFile, targetPath);
 
-            using (var reportTextWriter = new StreamWriter(new FileStream(targetPath, FileMode.Create), Encoding.UTF8))
+            using (var reportTextWriter = File.CreateText(targetPath))
             {
                 HistoricCoverage previous = historicCoverages[0];
                 HistoricCoverage current = historicCoverages[1];

--- a/src/ReportGenerator.Core/Reporting/Builders/TextSummaryReportBuilder.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/TextSummaryReportBuilder.cs
@@ -81,7 +81,7 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders
 
             Logger.InfoFormat(Resources.WritingReportFile, targetPath);
 
-            using (var reportTextWriter = new StreamWriter(new FileStream(targetPath, FileMode.Create), Encoding.UTF8))
+            using (var reportTextWriter = File.CreateText(targetPath))
             {
                 reportTextWriter.WriteLine(ReportResources.Summary);
                 reportTextWriter.WriteLine("  {0} {1}", ReportResources.GeneratedOn, DateTime.Now.ToShortDateString() + " - " + DateTime.Now.ToLongTimeString());


### PR DESCRIPTION
This PR proposes to remove the UTF-8 BOM from the text reports. The BOM doesn't add much value in them yet avoids problems with programs that don't work well with its presence. If ever really needed, it could be added back via a CLI option.