### PR TITLE
Only skip the found line, not the whole file

### DIFF
--- a/src/ReportGenerator.Core/Reporting/Builders/SonarQubeBuilder.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/SonarQubeBuilder.cs
@@ -172,7 +172,7 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders
                             }
                         }
 
-                        return;
+                        continue;
                     }
                 }
 


### PR DESCRIPTION
When using multiple coverage reports as input for the SonarQube format, then the coverage is not correctly merged.
The reason for this is that the SonarCubeBuilder skips the whole file if an existing line is found in an existing file.
With this PR this behavior is fixed, so that only the existing line is not added a second time.