### PR TITLE
Added a calculated figure for CRAP score for cobertura reports.

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -17,3 +17,4 @@ obj
 .DS_Store
 .AssemblyAttributes
 node_modules
+/_ReSharper.Caches


### PR DESCRIPTION
Added a calculated figure for CRAP score for cobertura coverage reports.  Also slight refactoring of the Cobertura metrics calculations to reduce repetition of parsing code.
closes #641