### PR TITLE
Fix sort direction triangles

### DIFF
--- a/src/AngularComponents/src/app/components/coverageinfo/coverage-info.component.ts
+++ b/src/AngularComponents/src/app/components/coverageinfo/coverage-info.component.ts
@@ -122,62 +122,62 @@ import { Helper } from "./viewmodels/helper.class";
             <td class="center" [attr.colspan]="settings.visibleMetrics.length" *ngIf="settings.visibleMetrics.length > 0"></td>
           </tr>
           <tr>
-            <th><a href="#" (click)="updateSorting('name', $event)"><i class="icon-down-dir"
-              [ngClass]="{'icon-up-dir_active': settings.sortBy === 'name' && settings.sortOrder === 'desc',
-              'icon-down-dir_active': settings.sortBy === 'name' && settings.sortOrder === 'asc',
-              'icon-down-dir': settings.sortBy !== 'name'}"></i>{{translations.name}}</a></th>
-            <th class="right" *ngIf="settings.showLineCoverage"><a href="#" (click)="updateSorting('covered', $event)"><i class="icon-down-dir"
-              [ngClass]="{'icon-up-dir_active': settings.sortBy === 'covered' && settings.sortOrder === 'desc',
-              'icon-down-dir_active': settings.sortBy === 'covered' && settings.sortOrder === 'asc',
-              'icon-down-dir': settings.sortBy !== 'covered'}"></i>{{translations.covered}}</a></th>
-            <th class="right" *ngIf="settings.showLineCoverage"><a href="#" (click)="updateSorting('uncovered', $event)"><i class="icon-down-dir"
-              [ngClass]="{'icon-up-dir_active': settings.sortBy === 'uncovered' && settings.sortOrder === 'desc',
-              'icon-down-dir_active': settings.sortBy === 'uncovered' && settings.sortOrder === 'asc',
-              'icon-down-dir': settings.sortBy !== 'uncovered'}"></i>{{translations.uncovered}}</a></th>
-            <th class="right" *ngIf="settings.showLineCoverage"><a href="#" (click)="updateSorting('coverable', $event)"><i class="icon-down-dir"
-                [ngClass]="{'icon-up-dir_active': settings.sortBy === 'coverable' && settings.sortOrder === 'desc',
-                'icon-down-dir_active': settings.sortBy === 'coverable' && settings.sortOrder === 'asc',
-                'icon-down-dir': settings.sortBy !== 'coverable'}"></i>{{translations.coverable}}</a></th>
-            <th class="right" *ngIf="settings.showLineCoverage"><a href="#" (click)="updateSorting('total', $event)"><i class="icon-down-dir"
-                [ngClass]="{'icon-up-dir_active': settings.sortBy === 'total' && settings.sortOrder === 'desc',
-                'icon-down-dir_active': settings.sortBy === 'total' && settings.sortOrder === 'asc',
-                'icon-down-dir': settings.sortBy !== 'total'}"></i>{{translations.total}}</a></th>
+            <th><a href="#" (click)="updateSorting('name', $event)"><i class="icon-up-dir"
+              [ngClass]="{'icon-up-dir_active': settings.sortBy === 'name' && settings.sortOrder === 'asc',
+              'icon-down-dir_active': settings.sortBy === 'name' && settings.sortOrder === 'desc',
+              'icon-up-dir': settings.sortBy !== 'name'}"></i>{{translations.name}}</a></th>
+            <th class="right" *ngIf="settings.showLineCoverage"><a href="#" (click)="updateSorting('covered', $event)"><i class="icon-up-dir"
+              [ngClass]="{'icon-up-dir_active': settings.sortBy === 'covered' && settings.sortOrder === 'asc',
+              'icon-down-dir_active': settings.sortBy === 'covered' && settings.sortOrder === 'desc',
+              'icon-up-dir': settings.sortBy !== 'covered'}"></i>{{translations.covered}}</a></th>
+            <th class="right" *ngIf="settings.showLineCoverage"><a href="#" (click)="updateSorting('uncovered', $event)"><i class="icon-up-dir"
+              [ngClass]="{'icon-up-dir_active': settings.sortBy === 'uncovered' && settings.sortOrder === 'asc',
+              'icon-down-dir_active': settings.sortBy === 'uncovered' && settings.sortOrder === 'desc',
+              'icon-up-dir': settings.sortBy !== 'uncovered'}"></i>{{translations.uncovered}}</a></th>
+            <th class="right" *ngIf="settings.showLineCoverage"><a href="#" (click)="updateSorting('coverable', $event)"><i class="icon-up-dir"
+                [ngClass]="{'icon-up-dir_active': settings.sortBy === 'coverable' && settings.sortOrder === 'asc',
+                'icon-down-dir_active': settings.sortBy === 'coverable' && settings.sortOrder === 'desc',
+                'icon-up-dir': settings.sortBy !== 'coverable'}"></i>{{translations.coverable}}</a></th>
+            <th class="right" *ngIf="settings.showLineCoverage"><a href="#" (click)="updateSorting('total', $event)"><i class="icon-up-dir"
+                [ngClass]="{'icon-up-dir_active': settings.sortBy === 'total' && settings.sortOrder === 'asc',
+                'icon-down-dir_active': settings.sortBy === 'total' && settings.sortOrder === 'desc',
+                'icon-up-dir': settings.sortBy !== 'total'}"></i>{{translations.total}}</a></th>
             <th class="center" colspan="2" *ngIf="settings.showLineCoverage">
-                <a href="#" (click)="updateSorting('coverage', $event)"><i class="icon-down-dir"
-                  [ngClass]="{'icon-up-dir_active': settings.sortBy === 'coverage' && settings.sortOrder === 'desc',
-                  'icon-down-dir_active': settings.sortBy === 'coverage' && settings.sortOrder === 'asc',
-                  'icon-down-dir': settings.sortBy !== 'coverage'}"></i>{{translations.percentage}}</a></th>
-            <th class="right" *ngIf="branchCoverageAvailable && settings.showBranchCoverage"><a href="#" (click)="updateSorting('covered_branches', $event)"><i class="icon-down-dir"
-              [ngClass]="{'icon-up-dir_active': settings.sortBy === 'covered_branches' && settings.sortOrder === 'desc',
-              'icon-down-dir_active': settings.sortBy === 'covered_branches' && settings.sortOrder === 'asc',
-              'icon-down-dir': settings.sortBy !== 'covered_branches'}"></i>{{translations.covered}}</a></th>
-            <th class="right" *ngIf="branchCoverageAvailable && settings.showBranchCoverage"><a href="#" (click)="updateSorting('total_branches', $event)"><i class="icon-down-dir"
-                [ngClass]="{'icon-up-dir_active': settings.sortBy === 'total_branches' && settings.sortOrder === 'desc',
-                'icon-down-dir_active': settings.sortBy === 'total_branches' && settings.sortOrder === 'asc',
-                'icon-down-dir': settings.sortBy !== 'total_branches'}"></i>{{translations.total}}</a></th>
+                <a href="#" (click)="updateSorting('coverage', $event)"><i class="icon-up-dir"
+                  [ngClass]="{'icon-up-dir_active': settings.sortBy === 'coverage' && settings.sortOrder === 'asc',
+                  'icon-down-dir_active': settings.sortBy === 'coverage' && settings.sortOrder === 'desc',
+                  'icon-up-dir': settings.sortBy !== 'coverage'}"></i>{{translations.percentage}}</a></th>
+            <th class="right" *ngIf="branchCoverageAvailable && settings.showBranchCoverage"><a href="#" (click)="updateSorting('covered_branches', $event)"><i class="icon-up-dir"
+              [ngClass]="{'icon-up-dir_active': settings.sortBy === 'covered_branches' && settings.sortOrder === 'asc',
+              'icon-down-dir_active': settings.sortBy === 'covered_branches' && settings.sortOrder === 'desc',
+              'icon-up-dir': settings.sortBy !== 'covered_branches'}"></i>{{translations.covered}}</a></th>
+            <th class="right" *ngIf="branchCoverageAvailable && settings.showBranchCoverage"><a href="#" (click)="updateSorting('total_branches', $event)"><i class="icon-up-dir"
+                [ngClass]="{'icon-up-dir_active': settings.sortBy === 'total_branches' && settings.sortOrder === 'asc',
+                'icon-down-dir_active': settings.sortBy === 'total_branches' && settings.sortOrder === 'desc',
+                'icon-up-dir': settings.sortBy !== 'total_branches'}"></i>{{translations.total}}</a></th>
             <th class="center" colspan="2" *ngIf="branchCoverageAvailable && settings.showBranchCoverage">
-                <a href="#" (click)="updateSorting('branchcoverage', $event)"><i class="icon-down-dir"
-                  [ngClass]="{'icon-up-dir_active': settings.sortBy === 'branchcoverage' && settings.sortOrder === 'desc',
-                  'icon-down-dir_active': settings.sortBy === 'branchcoverage' && settings.sortOrder === 'asc',
-                  'icon-down-dir': settings.sortBy !== 'branchcoverage'}"></i>{{translations.percentage}}</a></th>
-            <th class="right" *ngIf="methodCoverageAvailable && settings.showMethodCoverage"><a href="#" (click)="updateSorting('covered_methods', $event)"><i class="icon-down-dir"
-              [ngClass]="{'icon-up-dir_active': settings.sortBy === 'covered_methods' && settings.sortOrder === 'desc',
-              'icon-down-dir_active': settings.sortBy === 'covered_methods' && settings.sortOrder === 'asc',
-              'icon-down-dir': settings.sortBy !== 'covered_methods'}"></i>{{translations.covered}}</a></th>
-            <th class="right" *ngIf="methodCoverageAvailable && settings.showMethodCoverage"><a href="#" (click)="updateSorting('total_methods', $event)"><i class="icon-down-dir"
-                [ngClass]="{'icon-up-dir_active': settings.sortBy === 'total_methods' && settings.sortOrder === 'desc',
-                'icon-down-dir_active': settings.sortBy === 'total_methods' && settings.sortOrder === 'asc',
-                'icon-down-dir': settings.sortBy !== 'total_methods'}"></i>{{translations.total}}</a></th>
+                <a href="#" (click)="updateSorting('branchcoverage', $event)"><i class="icon-up-dir"
+                  [ngClass]="{'icon-up-dir_active': settings.sortBy === 'branchcoverage' && settings.sortOrder === 'asc',
+                  'icon-down-dir_active': settings.sortBy === 'branchcoverage' && settings.sortOrder === 'desc',
+                  'icon-up-dir': settings.sortBy !== 'branchcoverage'}"></i>{{translations.percentage}}</a></th>
+            <th class="right" *ngIf="methodCoverageAvailable && settings.showMethodCoverage"><a href="#" (click)="updateSorting('covered_methods', $event)"><i class="icon-up-dir"
+              [ngClass]="{'icon-up-dir_active': settings.sortBy === 'covered_methods' && settings.sortOrder === 'asc',
+              'icon-down-dir_active': settings.sortBy === 'covered_methods' && settings.sortOrder === 'desc',
+              'icon-up-dir': settings.sortBy !== 'covered_methods'}"></i>{{translations.covered}}</a></th>
+            <th class="right" *ngIf="methodCoverageAvailable && settings.showMethodCoverage"><a href="#" (click)="updateSorting('total_methods', $event)"><i class="icon-up-dir"
+                [ngClass]="{'icon-up-dir_active': settings.sortBy === 'total_methods' && settings.sortOrder === 'asc',
+                'icon-down-dir_active': settings.sortBy === 'total_methods' && settings.sortOrder === 'desc',
+                'icon-up-dir': settings.sortBy !== 'total_methods'}"></i>{{translations.total}}</a></th>
             <th class="center" colspan="2" *ngIf="methodCoverageAvailable && settings.showMethodCoverage">
-                <a href="#" (click)="updateSorting('methodcoverage', $event)"><i class="icon-down-dir"
-                  [ngClass]="{'icon-up-dir_active': settings.sortBy === 'methodcoverage' && settings.sortOrder === 'desc',
-                  'icon-down-dir_active': settings.sortBy === 'methodcoverage' && settings.sortOrder === 'asc',
-                  'icon-down-dir': settings.sortBy !== 'methodcoverage'}"></i>{{translations.percentage}}</a></th>
+                <a href="#" (click)="updateSorting('methodcoverage', $event)"><i class="icon-up-dir"
+                  [ngClass]="{'icon-up-dir_active': settings.sortBy === 'methodcoverage' && settings.sortOrder === 'asc',
+                  'icon-down-dir_active': settings.sortBy === 'methodcoverage' && settings.sortOrder === 'desc',
+                  'icon-up-dir': settings.sortBy !== 'methodcoverage'}"></i>{{translations.percentage}}</a></th>
             <th *ngFor="let metric of settings.visibleMetrics">
-              <a href="#" (click)="updateSorting(metric.abbreviation, $event)"><i class="icon-down-dir"
-                  [ngClass]="{'icon-up-dir_active': settings.sortBy === metric.abbreviation && settings.sortOrder === 'desc',
-                  'icon-down-dir_active': settings.sortBy === metric.abbreviation && settings.sortOrder === 'asc',
-                  'icon-down-dir': settings.sortBy !== metric.abbreviation}"></i>{{metric.name}}</a><a href="{{metric.explanationUrl}}" target="_blank"><i class="icon-info-circled"></i></a>
+              <a href="#" (click)="updateSorting(metric.abbreviation, $event)"><i class="icon-up-dir"
+                  [ngClass]="{'icon-up-dir_active': settings.sortBy === metric.abbreviation && settings.sortOrder === 'asc',
+                  'icon-down-dir_active': settings.sortBy === metric.abbreviation && settings.sortOrder === 'desc',
+                  'icon-up-dir': settings.sortBy !== metric.abbreviation}"></i>{{metric.name}}</a><a href="{{metric.explanationUrl}}" target="_blank"><i class="icon-info-circled"></i></a>
             </th>
           </tr>
         </thead>

--- a/src/AngularComponents/src/app/components/riskhotspots/riskhotspots.component.ts
+++ b/src/AngularComponents/src/app/components/riskhotspots/riskhotspots.component.ts
@@ -44,21 +44,21 @@ import { RiskHotspotsSettings } from "./data/riskhotspots-settings.class";
           <thead>
             <tr>
               <th><a href="#" (click)="updateSorting('assembly', $event)"><i class="icon-down-dir"
-                [ngClass]="{'icon-up-dir_active': settings.sortBy === 'assembly' && settings.sortOrder === 'desc',
-                'icon-down-dir_active': settings.sortBy === 'assembly' && settings.sortOrder === 'asc',
+                [ngClass]="{'icon-up-dir_active': settings.sortBy === 'assembly' && settings.sortOrder === 'asc',
+                'icon-down-dir_active': settings.sortBy === 'assembly' && settings.sortOrder === 'desc',
                 'icon-down-dir': settings.sortBy !== 'assembly'}"></i>{{translations.assembly}}</a></th>
               <th><a href="#" (click)="updateSorting('class', $event)"><i class="icon-down-dir"
-              [ngClass]="{'icon-up-dir_active': settings.sortBy === 'class' && settings.sortOrder === 'desc',
-              'icon-down-dir_active': settings.sortBy === 'class' && settings.sortOrder === 'asc',
+              [ngClass]="{'icon-up-dir_active': settings.sortBy === 'class' && settings.sortOrder === 'asc',
+              'icon-down-dir_active': settings.sortBy === 'class' && settings.sortOrder === 'desc',
               'icon-down-dir': settings.sortBy !== 'class'}"></i>{{translations.class}}</a></th>
               <th><a href="#" (click)="updateSorting('method', $event)"><i class="icon-down-dir"
-              [ngClass]="{'icon-up-dir_active': settings.sortBy === 'method' && settings.sortOrder === 'desc',
-              'icon-down-dir_active': settings.sortBy === 'method' && settings.sortOrder === 'asc',
+              [ngClass]="{'icon-up-dir_active': settings.sortBy === 'method' && settings.sortOrder === 'asc',
+              'icon-down-dir_active': settings.sortBy === 'method' && settings.sortOrder === 'desc',
               'icon-down-dir': settings.sortBy !== 'method'}"></i>{{translations.method}}</a></th>
               <th *ngFor="let riskHotspotMetric of riskHotspotMetrics; index as i">
                 <a href="#" (click)="updateSorting('' + i, $event)"><i class="icon-down-dir"
-                [ngClass]="{'icon-up-dir_active': settings.sortBy === '' + i && settings.sortOrder === 'desc',
-                'icon-down-dir_active': settings.sortBy === '' + i && settings.sortOrder === 'asc',
+                [ngClass]="{'icon-up-dir_active': settings.sortBy === '' + i && settings.sortOrder === 'asc',
+                'icon-down-dir_active': settings.sortBy === '' + i && settings.sortOrder === 'desc',
                 'icon-down-dir': settings.sortBy !== '' + i}"></i>{{riskHotspotMetric.name}}</a>
                 <a href="{{riskHotspotMetric.explanationUrl}}" target="_blank"><i class="icon-info-circled"></i></a>
               </th>

--- a/src/AngularComponents/src/app/components/riskhotspots/riskhotspots.component.ts
+++ b/src/AngularComponents/src/app/components/riskhotspots/riskhotspots.component.ts
@@ -43,23 +43,23 @@ import { RiskHotspotsSettings } from "./data/riskhotspots-settings.class";
           </colgroup>
           <thead>
             <tr>
-              <th><a href="#" (click)="updateSorting('assembly', $event)"><i class="icon-down-dir"
+              <th><a href="#" (click)="updateSorting('assembly', $event)"><i class="icon-up-dir"
                 [ngClass]="{'icon-up-dir_active': settings.sortBy === 'assembly' && settings.sortOrder === 'asc',
                 'icon-down-dir_active': settings.sortBy === 'assembly' && settings.sortOrder === 'desc',
-                'icon-down-dir': settings.sortBy !== 'assembly'}"></i>{{translations.assembly}}</a></th>
-              <th><a href="#" (click)="updateSorting('class', $event)"><i class="icon-down-dir"
+                'icon-up-dir': settings.sortBy !== 'assembly'}"></i>{{translations.assembly}}</a></th>
+              <th><a href="#" (click)="updateSorting('class', $event)"><i class="icon-up-dir"
               [ngClass]="{'icon-up-dir_active': settings.sortBy === 'class' && settings.sortOrder === 'asc',
               'icon-down-dir_active': settings.sortBy === 'class' && settings.sortOrder === 'desc',
-              'icon-down-dir': settings.sortBy !== 'class'}"></i>{{translations.class}}</a></th>
-              <th><a href="#" (click)="updateSorting('method', $event)"><i class="icon-down-dir"
+              'icon-up-dir': settings.sortBy !== 'class'}"></i>{{translations.class}}</a></th>
+              <th><a href="#" (click)="updateSorting('method', $event)"><i class="icon-up-dir"
               [ngClass]="{'icon-up-dir_active': settings.sortBy === 'method' && settings.sortOrder === 'asc',
               'icon-down-dir_active': settings.sortBy === 'method' && settings.sortOrder === 'desc',
-              'icon-down-dir': settings.sortBy !== 'method'}"></i>{{translations.method}}</a></th>
+              'icon-up-dir': settings.sortBy !== 'method'}"></i>{{translations.method}}</a></th>
               <th *ngFor="let riskHotspotMetric of riskHotspotMetrics; index as i">
-                <a href="#" (click)="updateSorting('' + i, $event)"><i class="icon-down-dir"
+                <a href="#" (click)="updateSorting('' + i, $event)"><i class="icon-up-dir"
                 [ngClass]="{'icon-up-dir_active': settings.sortBy === '' + i && settings.sortOrder === 'asc',
                 'icon-down-dir_active': settings.sortBy === '' + i && settings.sortOrder === 'desc',
-                'icon-down-dir': settings.sortBy !== '' + i}"></i>{{riskHotspotMetric.name}}</a>
+                'icon-up-dir': settings.sortBy !== '' + i}"></i>{{riskHotspotMetric.name}}</a>
                 <a href="{{riskHotspotMetric.explanationUrl}}" target="_blank"><i class="icon-info-circled"></i></a>
               </th>
             </tr>


### PR DESCRIPTION
Risk hotspots and coverage info tables' triangle icons show incorrect sorting direction.

The triangles represent a stack of items like a [Tower of Hanoi](https://en.wikipedia.org/wiki/Tower_of_Hanoi) toy.

- An upwards-pointing triangle ▲ represents a stack with the narrowest (ie, smallest) item on top and the widest (ie, largest) item on the bottom, hence an ascending list.

- A downwards-pointing triangle ▼ represents a stack with the widest (ie, largest) item on top and the narrowest (ie, smallest) item on the bottom, hence a descending list.