### PR TITLE
Optimise memory allocations in `HtmlRenderer`.

### DIFF
--- a/src/ReportGenerator.Core/ReportGenerator.Core.csproj
+++ b/src/ReportGenerator.Core/ReportGenerator.Core.csproj
@@ -87,6 +87,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.8" />
     <PackageReference Include="System.Text.Json" Version="8.0.4" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This is mainly done by avoiding creating additional `StringBuilder`s and writing direct to the `TextWriter` where possible. Where `StringBuilder`s are still needed, they're pooled and reused

Saves on the amount of allocated memory and time paused for GC.

I haven't measured a huge improvement in end to end report generation (maybe a second, but hard to say if that's within run to run variance), however reduction in allocations helps and this change does have measurable impacts when combined with my next PR.

Below are the perfview Results with my playground - built on top of the app from #691 with an an additional call to `ReportGenerator.GenerateReport`.  
```cs
// Generate the html report with custom configuration for report generator.
var reportGeneratorConfig = new ReportConfigurationBuilder().Create(new Dictionary<string, string>() {
                { "targetdir", targetDir },
                { "sourcedirs", ".\\src" },
                { "reporttypes", "HtmlInline_AzurePipelines" }
            });

var generator = new Generator() { };
var settings = new Settings() { };

stopwatch.Restart();
generator.GenerateReport(reportGeneratorConfig, settings, new RiskHotspotsAnalysisThresholds(), results);

Console.WriteLine($"ELAPSED: {stopwatch}");
```

## Before

> - CommandLine: ".\ReportGenerator\src\Playground\bin\Debug\net8.0\Playground.exe"
> - Runtime Version: V 8.0.824.36612
> - CLR Startup Flags: 8388611
> - Total CPU Time: 38,443 msec
> - Total GC CPU Time: 1,666 msec
> - Total Allocs : 8,378.712 MB
> - Number of Heaps: 1
> - GC CPU MSec/MB Alloc : 0.199 MSec/MB
> - Total GC Pause: 2,567.9 msec
> - % Time paused for Garbage Collection: 8.1%
> - % CPU Time spent Garbage Collecting: 4.3%
> - Max GC Heap Size: 335.820 MB
> - Peak Process Working Set: 395.698 MB
> - Peak Virtual Memory Usage: 2,480,960.369 MB

## After

> - CommandLine: ".\ReportGenerator\src\Playground\bin\Debug\net8.0\Playground.exe"
> - Runtime Version: V 8.0.824.36612
> - CLR Startup Flags: 8388611
> - Total CPU Time: 28,247 msec
> - Total GC CPU Time: 1,183 msec
> - Total Allocs : 2,938.748 MB
> - Number of Heaps: 1
> - GC CPU MSec/MB Alloc : 0.403 MSec/MB
> - Total GC Pause: 1,348.8 msec
> - % Time paused for Garbage Collection: 6.2%
> - % CPU Time spent Garbage Collecting: 4.2%
> - Max GC Heap Size: 352.258 MB
> - Peak Process Working Set: 417.976 MB
> - Peak Virtual Memory Usage: 2,480,959.902 MB