### PR TITLE
Parallelise Report Generator

### DIFF
--- a/src/ReportGenerator.Core/Reporting/Builders/HtmlBlueRedReportBuilder.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/HtmlBlueRedReportBuilder.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using Palmmedia.ReportGenerator.Core.Parser.Analysis;
@@ -18,7 +19,7 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders
         /// <summary>
         /// Dictionary containing the filenames of the class reports by class.
         /// </summary>
-        private readonly IDictionary<string, string> fileNameByClass = new Dictionary<string, string>();
+        private readonly ConcurrentDictionary<string, string> fileNameByClass = new ConcurrentDictionary<string, string>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HtmlBlueRedReportBuilder" /> class.

--- a/src/ReportGenerator.Core/Reporting/Builders/HtmlBlueRedSummaryReportBuilder.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/HtmlBlueRedSummaryReportBuilder.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using Palmmedia.ReportGenerator.Core.Parser.Analysis;
@@ -33,7 +34,7 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders
         /// <param name="summaryResult">The summary result.</param>
         public override void CreateSummaryReport(SummaryResult summaryResult)
         {
-            using (var renderer = new HtmlRenderer(new Dictionary<string, string>(), true, HtmlMode.InlineCssAndJavaScript, new string[] { "custom_adaptive.css", "custom_bluered.css" }, "custom.css"))
+            using (var renderer = new HtmlRenderer(new ConcurrentDictionary<string, string>(), true, HtmlMode.InlineCssAndJavaScript, new string[] { "custom_adaptive.css", "custom_bluered.css" }, "custom.css"))
             {
                 this.CreateSummaryReport(renderer, summaryResult);
             }

--- a/src/ReportGenerator.Core/Reporting/Builders/HtmlDarkReportBuilder.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/HtmlDarkReportBuilder.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using Palmmedia.ReportGenerator.Core.Parser.Analysis;
@@ -18,7 +19,7 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders
         /// <summary>
         /// Dictionary containing the filenames of the class reports by class.
         /// </summary>
-        private readonly IDictionary<string, string> fileNameByClass = new Dictionary<string, string>();
+        private readonly ConcurrentDictionary<string, string> fileNameByClass = new ConcurrentDictionary<string, string>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HtmlDarkReportBuilder" /> class.

--- a/src/ReportGenerator.Core/Reporting/Builders/HtmlInlineAzurePipelinesDarkReportBuilder.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/HtmlInlineAzurePipelinesDarkReportBuilder.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using Palmmedia.ReportGenerator.Core.Parser.Analysis;
@@ -13,7 +14,7 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders
         /// <summary>
         /// Dictionary containing the filenames of the class reports by class.
         /// </summary>
-        private readonly IDictionary<string, string> fileNameByClass = new Dictionary<string, string>();
+        private readonly ConcurrentDictionary<string, string> fileNameByClass = new ConcurrentDictionary<string, string>();
 
         /// <summary>
         /// Gets the report type.

--- a/src/ReportGenerator.Core/Reporting/Builders/HtmlInlineAzurePipelinesLightReportBuilder.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/HtmlInlineAzurePipelinesLightReportBuilder.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using Palmmedia.ReportGenerator.Core.Parser.Analysis;
@@ -13,7 +14,7 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders
         /// <summary>
         /// Dictionary containing the filenames of the class reports by class.
         /// </summary>
-        private readonly IDictionary<string, string> fileNameByClass = new Dictionary<string, string>();
+        private readonly ConcurrentDictionary<string, string> fileNameByClass = new ConcurrentDictionary<string, string>();
 
         /// <summary>
         /// Gets the report type.

--- a/src/ReportGenerator.Core/Reporting/Builders/HtmlInlineAzurePipelinesReportBuilder.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/HtmlInlineAzurePipelinesReportBuilder.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using Palmmedia.ReportGenerator.Core.Parser.Analysis;
@@ -13,7 +14,7 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders
         /// <summary>
         /// Dictionary containing the filenames of the class reports by class.
         /// </summary>
-        private readonly IDictionary<string, string> fileNameByClass = new Dictionary<string, string>();
+        private readonly ConcurrentDictionary<string, string> fileNameByClass = new ConcurrentDictionary<string, string>();
 
         /// <summary>
         /// Gets the report type.

--- a/src/ReportGenerator.Core/Reporting/Builders/HtmlInlineCssAndJavaScriptReportBuilder.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/HtmlInlineCssAndJavaScriptReportBuilder.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using Palmmedia.ReportGenerator.Core.Parser.Analysis;
@@ -13,7 +14,7 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders
         /// <summary>
         /// Dictionary containing the filenames of the class reports by class.
         /// </summary>
-        private readonly IDictionary<string, string> fileNameByClass = new Dictionary<string, string>();
+        private readonly ConcurrentDictionary<string, string> fileNameByClass = new ConcurrentDictionary<string, string>();
 
         /// <summary>
         /// Gets the report type.

--- a/src/ReportGenerator.Core/Reporting/Builders/HtmlLightReportBuilder.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/HtmlLightReportBuilder.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using Palmmedia.ReportGenerator.Core.Parser.Analysis;
@@ -18,7 +19,7 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders
         /// <summary>
         /// Dictionary containing the filenames of the class reports by class.
         /// </summary>
-        private readonly IDictionary<string, string> fileNameByClass = new Dictionary<string, string>();
+        private readonly ConcurrentDictionary<string, string> fileNameByClass = new ConcurrentDictionary<string, string>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HtmlLightReportBuilder" /> class.

--- a/src/ReportGenerator.Core/Reporting/Builders/HtmlReportBuilder.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/HtmlReportBuilder.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using Palmmedia.ReportGenerator.Core.Parser.Analysis;
@@ -18,7 +19,7 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders
         /// <summary>
         /// Dictionary containing the filenames of the class reports by class.
         /// </summary>
-        private readonly IDictionary<string, string> fileNameByClass = new Dictionary<string, string>();
+        private readonly ConcurrentDictionary<string, string> fileNameByClass = new ConcurrentDictionary<string, string>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HtmlReportBuilder" /> class.

--- a/src/ReportGenerator.Core/Reporting/Builders/HtmlReportBuilderBase.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/HtmlReportBuilderBase.cs
@@ -15,7 +15,7 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders
     /// <summary>
     /// Implementation of <see cref="IReportBuilder"/> that uses <see cref="IHtmlRenderer"/> to create reports.
     /// </summary>
-    public abstract class HtmlReportBuilderBase : IReportBuilder
+    public abstract class HtmlReportBuilderBase : IParallelisableReportBuilder
     {
         /// <summary>
         /// The Logger.

--- a/src/ReportGenerator.Core/Reporting/Builders/HtmlSummaryReportBuilder.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/HtmlSummaryReportBuilder.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using Palmmedia.ReportGenerator.Core.Parser.Analysis;
@@ -33,7 +34,7 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders
         /// <param name="summaryResult">The summary result.</param>
         public override void CreateSummaryReport(SummaryResult summaryResult)
         {
-            using (var renderer = new HtmlRenderer(new Dictionary<string, string>(), true, HtmlMode.InlineCssAndJavaScript))
+            using (var renderer = new HtmlRenderer(new ConcurrentDictionary<string, string>(), true, HtmlMode.InlineCssAndJavaScript))
             {
                 this.CreateSummaryReport(renderer, summaryResult);
             }

--- a/src/ReportGenerator.Core/Reporting/Builders/Rendering/HtmlRenderer.cs
+++ b/src/ReportGenerator.Core/Reporting/Builders/Rendering/HtmlRenderer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -58,7 +59,7 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders.Rendering
         /// <summary>
         /// Dictionary containing the filenames of the class reports by class.
         /// </summary>
-        private readonly IDictionary<string, string> fileNameByClass;
+        private readonly ConcurrentDictionary<string, string> fileNameByClass;
 
         /// <summary>
         /// Indicates that only a summary report is created (no class reports).
@@ -109,7 +110,7 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders.Rendering
         /// <param name="cssFileResource">Optional CSS file resource.</param>
         /// <param name="additionalCssFileResource">Optional additional CSS file resource.</param>
         internal HtmlRenderer(
-            IDictionary<string, string> fileNameByClass,
+            ConcurrentDictionary<string, string> fileNameByClass,
             bool onlySummary,
             HtmlMode htmlMode,
             string cssFileResource = "custom.css",
@@ -132,7 +133,7 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders.Rendering
         /// <param name="additionalCssFileResources">Optional additional CSS file resources.</param>
         /// <param name="cssFileResource">Optional CSS file resource.</param>
         internal HtmlRenderer(
-            IDictionary<string, string> fileNameByClass,
+            ConcurrentDictionary<string, string> fileNameByClass,
             bool onlySummary,
             HtmlMode htmlMode,
             string[] additionalCssFileResources,
@@ -1557,7 +1558,7 @@ namespace Palmmedia.ReportGenerator.Core.Reporting.Builders.Rendering
                     while (this.fileNameByClass.Values.Any(v => v.Equals(fileName, StringComparison.OrdinalIgnoreCase)));
                 }
 
-                this.fileNameByClass.Add(key, fileName);
+                this.fileNameByClass[key] = fileName;
             }
 
             return fileName;

--- a/src/ReportGenerator.Core/Reporting/IParallelisableReportBuilder.cs
+++ b/src/ReportGenerator.Core/Reporting/IParallelisableReportBuilder.cs
@@ -1,0 +1,7 @@
+﻿namespace Palmmedia.ReportGenerator.Core.Reporting
+{
+    /// <summary>
+    /// Interface indicating that an <see cref="IReportBuilder"/> can build multiple reports concurrently.
+    /// </summary>
+    public interface IParallelisableReportBuilder : IReportBuilder { }
+}


### PR DESCRIPTION
I've had a go at trying to parallelise the report generation - aimed particularly at helping GitHub Actions / Azure DevOps where the report generator can be quite slow, presumably due to disk IO.  I've read some issues about previous attempts and realised it's not as simple as processing classes in parallel as not all the `IReportBuilder` implements support concurrency.

With this in mind, I believe two parts of the report generation process (`ReportGenerator`) can be parallelised

1. The initial File Analysis can be done concurrently with the report generation
2. Introduced `IParallelisableReportBuilder` - `IReportBuilder`s that also implement `IParallelisableReportBuilder` can then be processed in parallel

this PR has a draft implementation of this, and with the change, I have been able to get report generation (measuring time spent in `Generator.GenerateReport`) down from 21 secs to down as low as 4 seconds with extreme concurrency, and 6secs with more reasonable concurrency levels.

This PR is still a bit of a work in progress - in particular I need to plumb the concurrency level through as a config option, and I also want to do some testing with GitHub Actions / Azure Devops.  However I wanted to raise it in it's current form for some initial thoughts on the approach.

Note, this parallelisation change highly benefits form #695