### PR TITLE
Fix merging of classes with non unique names.

### DIFF
--- a/src/ReportGenerator.Core/Parser/Analysis/Assembly.cs
+++ b/src/ReportGenerator.Core/Parser/Analysis/Assembly.cs
@@ -177,7 +177,7 @@ namespace Palmmedia.ReportGenerator.Core.Parser.Analysis
 
             foreach (var @class in assembly.classes)
             {
-                var existingClass = this.classes.FirstOrDefault(c => c.Name == @class.Name);
+                var existingClass = this.classes.FirstOrDefault(c => c.Equals(@class));
 
                 if (existingClass != null)
                 {


### PR DESCRIPTION
Fixes #690, specifically around merging of reports with non unique class names.

Extends the fix from 78a1a92 to also apply to merging.