### PR TITLE
Fixed splitting of possible glob patterns

### DIFF
--- a/src/ReportGenerator.Core.Test/Common/StringExtensionsTest.cs
+++ b/src/ReportGenerator.Core.Test/Common/StringExtensionsTest.cs
@@ -13,5 +13,15 @@ namespace Palmmedia.ReportGenerator.Core.Test.Common
             Assert.Equal(1000, "1000".ParseLargeInteger());
             Assert.Equal(int.MaxValue, "2147483649".ParseLargeInteger());
         }
+
+        [Theory]
+        [InlineData("a,b,c", new[] { "a", "b", "c" })]
+        [InlineData("a,{b,c};d", new[] { "a", "{b,c}", "d" })]
+        [InlineData("a,{b,c;d", new[] { "a", "{b", "c", "d" })]
+        public void SplitThatEnsuresGlobsAreSafe_CorrectResultReturned(string input, string[] expectedParts)
+        {
+            var result = input.SplitThatEnsuresGlobsAreSafe(',', ';');
+            Assert.Equal(expectedParts, result);
+        }
     }
 }

--- a/src/ReportGenerator.Core/Common/StringExtensions.cs
+++ b/src/ReportGenerator.Core/Common/StringExtensions.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 
 namespace Palmmedia.ReportGenerator.Core.Common
 {
@@ -23,6 +25,54 @@ namespace Palmmedia.ReportGenerator.Core.Common
             {
                 return int.MaxValue;
             }
+        }
+
+        /// <summary>
+        /// Splits the string at the specified separator, but ensures that globs are not split.
+        /// </summary>
+        /// <param name="input">The input string.</param>
+        /// <param name="separators">List of separators.</param>
+        /// <returns>The parts.</returns>
+        public static string[] SplitThatEnsuresGlobsAreSafe(this string input, params char[] separators)
+        {
+            if (separators == null || separators.Length == 0)
+            {
+                return new string[] { input };
+            }
+
+            var parts = new List<string>();
+            var braceCount = 0;
+            var start = 0;
+
+            for (int i = 0; i < input.Length; i++)
+            {
+                if (input[i] == '{')
+                {
+                    braceCount++;
+                }
+                else if (input[i] == '}')
+                {
+                    braceCount--;
+                }
+
+                if (braceCount > 0 && input.IndexOf('}', i + 1) == -1)
+                {
+                    braceCount = 0;
+                }
+
+                if (separators.Contains(input[i]) && braceCount == 0)
+                {
+                    parts.Add(input.Substring(start, i - start).Trim());
+                    start = i + 1;
+                }
+            }
+
+            if (start < input.Length)
+            {
+                parts.Add(input.Substring(start).Trim());
+            }
+
+            return parts.ToArray();
         }
     }
 }

--- a/src/ReportGenerator.Core/ReportConfigurationBuilder.cs
+++ b/src/ReportGenerator.Core/ReportConfigurationBuilder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using DotNetConfig;
+using Palmmedia.ReportGenerator.Core.Common;
 using Palmmedia.ReportGenerator.Core.Logging;
 using Palmmedia.ReportGenerator.Core.Properties;
 
@@ -53,11 +54,11 @@ namespace Palmmedia.ReportGenerator.Core
 
             if (namedArguments.TryGetValue(CommandLineArgumentNames.Reports, out value))
             {
-                reportFilePatterns = value.Split(ArgumentSeparators, StringSplitOptions.RemoveEmptyEntries);
+                reportFilePatterns = value.SplitThatEnsuresGlobsAreSafe(ArgumentSeparators);
             }
             else if (config.TryGetString(DotNetConfigSettingNames.Reports, out value))
             {
-                reportFilePatterns = value.Split(ArgumentSeparators, StringSplitOptions.RemoveEmptyEntries);
+                reportFilePatterns = value.SplitThatEnsuresGlobsAreSafe(ArgumentSeparators);
             }
             else
             {

--- a/src/ReportGenerator.MSBuild/ReportGenerator.cs
+++ b/src/ReportGenerator.MSBuild/ReportGenerator.cs
@@ -5,6 +5,7 @@ using DotNetConfig;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Palmmedia.ReportGenerator.Core;
+using Palmmedia.ReportGenerator.Core.Common;
 
 namespace Palmmedia.ReportGenerator.MSBuild
 {
@@ -190,7 +191,7 @@ namespace Palmmedia.ReportGenerator.MSBuild
             }
             else if (config.TryGetString(DotNetConfigSettingNames.Reports, out value))
             {
-                reportFilePatterns = value.Split(ArgumentSeparators, StringSplitOptions.RemoveEmptyEntries);
+                reportFilePatterns = value.SplitThatEnsuresGlobsAreSafe(ArgumentSeparators);
             }
             else
             {


### PR DESCRIPTION
This should fix https://github.com/danielpalme/ReportGenerator-GitHub-Action/issues/22 by implementing a new splitting method that is aware of curly braces since they are used in group conditions in globs.

I couldn't run all the tests locally though since I'm on a mac and a lot of the tests uses file paths with \ in them.