### PR TITLE
Add Cobertura exported from Swift support

### DIFF
--- a/src/ReportGenerator.Core.Test/FileManager.cs
+++ b/src/ReportGenerator.Core.Test/FileManager.cs
@@ -71,6 +71,8 @@ namespace Palmmedia.ReportGenerator.Core.Test
 
         internal static string GetCtcReportsDirectory() => Path.Combine(GetFilesDirectory(), "CTC");
 
+        internal static string GetOtherReportsDirectory() => Path.Combine(GetFilesDirectory(), "Other");
+
         internal static string GetFilesDirectory()
         {
             if (filesDirectory == null)

--- a/src/ReportGenerator.Core/Parser/CoberturaParser.cs
+++ b/src/ReportGenerator.Core/Parser/CoberturaParser.cs
@@ -113,9 +113,10 @@ namespace Palmmedia.ReportGenerator.Core.Parser
         private Assembly ProcessAssembly(XElement[] modules, string assemblyName)
         {
             Logger.DebugFormat(Resources.CurrentAssembly, assemblyName);
-
-            var classes = modules
-                .Elements("classes")
+            var classesParent = modules.Elements("classes").Any()
+                ? modules.Elements("classes")
+                : modules;
+            var classes = classesParent
                 .Elements("class")
                 .ToArray();
 
@@ -270,7 +271,13 @@ namespace Palmmedia.ReportGenerator.Core.Parser
         {
             foreach (var method in methodsOfFile)
             {
-                string fullName = method.Attribute("name").Value + method.Attribute("signature").Value;
+                string fullName = method.Attribute("name").Value;
+                var signature = method.Attribute("signature")?.Value;
+                if (signature != null)
+                {
+                    fullName += signature;
+                }
+
                 string methodName = this.ExtractMethodName(fullName, method.Parent.Parent.Attribute("name").Value);
 
                 if (!this.RawMode && methodName.Contains("__") && LambdaMethodNameRegex.IsMatch(methodName))
@@ -458,7 +465,13 @@ namespace Palmmedia.ReportGenerator.Core.Parser
         {
             foreach (var method in methodsOfFile)
             {
-                string fullName = method.Attribute("name").Value + method.Attribute("signature").Value;
+                string fullName = method.Attribute("name").Value;
+                var signature = method.Attribute("signature")?.Value;
+                if (signature != null)
+                {
+                    fullName += signature;
+                }
+
                 string methodName = this.ExtractMethodName(fullName, method.Parent.Parent.Attribute("name").Value);
 
                 if (!this.RawMode && methodName.Contains("__") && LambdaMethodNameRegex.IsMatch(methodName))

--- a/src/ReportGenerator.sln
+++ b/src/ReportGenerator.sln
@@ -92,6 +92,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Other", "Other", "{0974779A
 		Testprojects\Other\Clover_Groovy.xml = Testprojects\Other\Clover_Groovy.xml
 		Testprojects\Other\Clover_Istanbul.xml = Testprojects\Other\Clover_Istanbul.xml
 		Testprojects\Other\Cobertura_Istanbul.xml = Testprojects\Other\Cobertura_Istanbul.xml
+		Testprojects\Other\Cobertura_Swift.xml = Testprojects\Other\Cobertura_Swift.xml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReportGenerator.MSBuild", "ReportGenerator.MSBuild\ReportGenerator.MSBuild.csproj", "{E0AC1EE8-82A3-41EE-BD42-44659CDBD333}"

--- a/src/Testprojects/Other/Cobertura_Swift.xml
+++ b/src/Testprojects/Other/Cobertura_Swift.xml
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<coverage branches-valid="1.0" branches-covered="1.0" branch-rate="1.0" complexity="0.0" lines-covered="1" lines-valid="2" timestamp="1764144659" line-rate="0.5">
+	<packages>
+		<package branch-rate="1.0" complexity="0.0" name="ComponentsTests/app" line-rate="0.5">
+			<class branch-rate="1.0" complexity="0.0" name="ComponentsTests/app/FirstTest/swift" filename="test_folder/firstTest.swift" line-rate="0.5">
+				<methods>
+					<method name="static URL.currentApplicationSupport.getter" line-rate="0" branch-rate="1.0" complexity="0.0">
+						<lines>
+							<line number="5" branch="false" hits="0" />
+						</lines>
+					</method>
+					<method name="implicit closure #1 in static URL.currentApplicationSupport.getter" line-rate="1" branch-rate="1.0" complexity="0.0">
+						<lines>
+							<line number="16" branch="false" hits="1" />
+						</lines>
+					</method>
+				</methods>
+			</class>
+		</package>
+	</packages>
+</coverage>


### PR DESCRIPTION
Problem:
The ReportGenerator does not find classes when parsing a report from Xcode (Swift) and returns empty metrics.

Root cause:
- The `classes` tag is missing in the Swift Cobertura xml;
- The `signature` attribute is also missing in the `method` tag.

Changes:
- Add possibility to parse Swift Cobertura;
- Add unit tests for Swift Cobertura line coverage metrics.