### PR TITLE
Fix memory leaks in Assembly classes

### DIFF
--- a/src/ReportGenerator.Core/Parser/Analysis/Assembly.cs
+++ b/src/ReportGenerator.Core/Parser/Analysis/Assembly.cs
@@ -14,7 +14,7 @@ namespace Palmmedia.ReportGenerator.Core.Parser.Analysis
         /// <summary>
         /// List of classes in assembly.
         /// </summary>
-        private readonly ConcurrentBag<Class> classes = new ConcurrentBag<Class>();
+        private readonly ConcurrentQueue<Class> classes = new ConcurrentQueue<Class>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Assembly"/> class.
@@ -175,7 +175,7 @@ namespace Palmmedia.ReportGenerator.Core.Parser.Analysis
         /// <param name="class">The class to add.</param>
         internal void AddClass(Class @class)
         {
-            this.classes.Add(@class);
+            this.classes.Enqueue(@class);
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
Replaced `ConcurrentBag` with `ConcurrentQueue` in `Assembly` to fix memory leaks caused by thread-local storage in long-running threads.

## Problem
`ConcurrentBag` maintains thread-local lists that aren't properly garbage collected after threads terminate, causing gradual memory growth in long-running applications.

## Solution
Switched to `ConcurrentQueue` which doesn't use thread-local storage and provides more predictable memory behavior.

## Changes
`src/ReportGenerator.Core/Parser/Analysis/Assembly.cs`: 
- Changed collection type from `ConcurrentBag<Class>` to `ConcurrentQueue<Class>` for `classes`;
- Updated relevant Add operation to Enqueue pattern.